### PR TITLE
Update asset.py

### DIFF
--- a/magenta_rt/asset.py
+++ b/magenta_rt/asset.py
@@ -30,7 +30,7 @@ from . import path as mrt_path
 
 GCP_BUCKET_NAME = 'magenta-rt-public'
 HF_REPO_NAME = 'google/magenta-realtime'
-DEFAULT_SOURCE = 'gcp'
+DEFAULT_SOURCE = 'hf'
 
 if 'MAGENTA_RT_CACHE_DIR' in os.environ:
   _CACHE_DIR = pathlib.Path(os.environ['MAGENTA_RT_CACHE_DIR'])


### PR DESCRIPTION
changed default source from gcp to huggingface

this avoid broken samples like 
https://github.com/magenta/magenta-realtime/issues/7 https://github.com/magenta/magenta-realtime/issues/8

check fix with this sample also : 
from magenta_rt import audio, spectrostream

codec = spectrostream.SpectroStream()
my_audio = audio.Waveform.from_file('jam.mp3')
my_tokens = codec.encode(my_audio)
my_audio_reconstruction = codec.decode(tokens)

in my failure case the access was denied to savedmodels/ssv2_48k_stereo/encoder