### PR TITLE
Fixes the prefilling

### DIFF
--- a/core/src/mlx_engine.cpp
+++ b/core/src/mlx_engine.cpp
@@ -659,7 +659,7 @@ bool MLXEngine::Impl::load_prefill_model(const char *spectrostream_mlxfn_path,
 //
 // Pipeline:
 //   1. Pad/truncate caller audio to the encoder's traced fixed shape
-//      (kEncoderInputSamples = 2880000 = 60 s).
+//      (kEncoderInputSamples = 1344000 = 28 s).
 //   2. Run the SpectroStream encoder → [1, 700, 16] RVQ tokens.
 //   3. Trim `trim_front_frames` from the start and `trim_back_frames`
 //      from the end of the token sequence; the kept range feeds the
@@ -725,11 +725,11 @@ bool MLXEngine::Impl::prefill_state(
 
   try {
     // The exported SpectroStream encoder is traced with a fixed input
-    // shape of `(1, kEncoderInputSamples, 2)` (about 28 s at 48 kHz),
+    // shape of `(1, kEncoderInputSamples, 2)` (28 s at 48 kHz),
     // so we must always pass exactly that many samples. Audio shorter
     // than that is zero-padded; longer audio is truncated. Tokens
     // corresponding to padded samples are excluded by the trim below.
-    constexpr int kEncoderInputSamples = 2880000;
+    constexpr int kEncoderInputSamples = 1344000;
     const int caller_audio_frames =
         num_samples / static_cast<int>(kFrameSamples);
     const int caller_audio_samples =
@@ -888,7 +888,7 @@ bool MLXEngine::Impl::ensure_silent_tokens(
   }
   try {
     // Encode a fully-silent 28 s buffer (the encoder's traced shape).
-    constexpr int kEncoderInputSamples = 2880000;
+    constexpr int kEncoderInputSamples = 1344000;
     std::vector<float> silent_input(kEncoderInputSamples * 2, 0.0f);
     mx::array waveform = mx::array(silent_input.data(),
                                    {1, kEncoderInputSamples, 2}, mx::float32);

--- a/examples/mrt2/auv3/MagentaRT_AudioUnit.mm
+++ b/examples/mrt2/auv3/MagentaRT_AudioUnit.mm
@@ -2053,7 +2053,7 @@ static BOOL paramIsBool(AUParameterAddress address) {
                                 // (1, 1344000, 2) = 28 s @ 48 kHz. We read
                                 // up to that and let the engine handle the
                                 // exact length internally.
-                                int maxFrames = 1344000; // 28s at 48kHz. todo: change to 60 seconds
+                                int maxFrames = 1344000; // 28s at 48kHz.
                                 std::vector<float> samples(maxFrames * 2, 0.0f);
 
                                 AudioBufferList bufferList;

--- a/examples/mrt2/auv3/MagentaRT_AudioUnit.mm
+++ b/examples/mrt2/auv3/MagentaRT_AudioUnit.mm
@@ -488,6 +488,27 @@ static BOOL isDevServerRunning(void) {
                             });
                         }
                         NSLog(@"MagentaRT_AU: Successfully auto-loaded model from bookmark.");
+
+                        // Load SpectroStream encoder: model dir → external spectrostream → bundle
+                        NSString* parentDir = [mlxfnPath stringByDeletingLastPathComponent];
+                        NSString* spectrostreamPath = [parentDir stringByAppendingPathComponent:@"spectrostream_encoder.mlxfn"];
+                        if ([[NSFileManager defaultManager] fileExistsAtPath:spectrostreamPath]) {
+                            NSLog(@"MagentaRT_AU: Auto-loading spectrostream encoder from model dir: %@", spectrostreamPath.lastPathComponent);
+                            self->_engine.load_prefill_model(spectrostreamPath.UTF8String, nullptr);
+                        } else {
+                            std::string extPath = magentart::paths::get_spectrostream_dir() + "/spectrostream_encoder.mlxfn";
+                            NSString* extNSPath = [NSString stringWithUTF8String:extPath.c_str()];
+                            if ([[NSFileManager defaultManager] fileExistsAtPath:extNSPath]) {
+                                NSLog(@"MagentaRT_AU: Auto-loading spectrostream encoder from external path: %@", extNSPath);
+                                self->_engine.load_prefill_model(extNSPath.UTF8String, nullptr);
+                            } else {
+                                NSString* fallbackPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"spectrostream_encoder" ofType:@"mlxfn"];
+                                if (fallbackPath) {
+                                    NSLog(@"MagentaRT_AU: Auto-loading spectrostream encoder from bundle: %@", fallbackPath.lastPathComponent);
+                                    self->_engine.load_prefill_model(fallbackPath.UTF8String, nullptr);
+                                }
+                            }
+                        }
                     } else {
                         NSLog(@"MagentaRT_AU: Failed to auto-load model from bookmark.");
                     }

--- a/examples/mrt2/auv3/README.md
+++ b/examples/mrt2/auv3/README.md
@@ -58,7 +58,7 @@ holds a saved state.
   full model reload. The factory snapshot is held in memory as a shallow
   `mx::array` copy, so this is cheap (no disk I/O, no recompilation).
 - **Custom** (upload icon, then replay icon) — **Audio Prefill**. Upload
-  a `.wav`/audio file (up to 60 s; the SpectroStream encoder is traced
+  a `.wav`/audio file (up to 28 seconds; the SpectroStream encoder is traced
   at that fixed length); it's encoded to RVQ tokens, the unreliable
   head/tail of the sequence is trimmed (1 s each side), and the tokens
   are fed through the transformer one frame at a time.
@@ -148,7 +148,7 @@ generation then takes over. The runner deliberately does **not** play
 back audio captured during the prefill loop itself — those would be
 the model's per-step *predictions* on a teacher-forced trajectory, and
 they accumulate audible artifacts at typical prefill lengths
-(currently up to 60 seconds).
+(currently up to 28 seconds).
 
 ### Why token prefill behaves differently
 

--- a/examples/mrt2/standalone/MagentaRTStandaloneApp.mm
+++ b/examples/mrt2/standalone/MagentaRTStandaloneApp.mm
@@ -662,6 +662,26 @@ using magentart::core::RealtimeRunner;
                 }
             }
 
+            // Load SpectroStream encoder: model dir → external spectrostream → bundle
+            NSString* spectrostreamPath = [parentDir stringByAppendingPathComponent:@"spectrostream_encoder.mlxfn"];
+            if ([[NSFileManager defaultManager] fileExistsAtPath:spectrostreamPath]) {
+                NSLog(@"MagentaRT Standalone: Auto-loading spectrostream encoder from model dir: %@", spectrostreamPath.lastPathComponent);
+                self->_engine.load_prefill_model(spectrostreamPath.UTF8String, nullptr);
+            } else {
+                std::string extPath = magentart::paths::get_spectrostream_dir() + "/spectrostream_encoder.mlxfn";
+                NSString* extNSPath = [NSString stringWithUTF8String:extPath.c_str()];
+                if ([[NSFileManager defaultManager] fileExistsAtPath:extNSPath]) {
+                    NSLog(@"MagentaRT Standalone: Auto-loading spectrostream encoder from external path: %@", extNSPath);
+                    self->_engine.load_prefill_model(extNSPath.UTF8String, nullptr);
+                } else {
+                    NSString* fallbackPath = [[NSBundle mainBundle] pathForResource:@"spectrostream_encoder" ofType:@"mlxfn"];
+                    if (fallbackPath) {
+                        NSLog(@"MagentaRT Standalone: Auto-loading spectrostream encoder from bundle: %@", fallbackPath.lastPathComponent);
+                        self->_engine.load_prefill_model(fallbackPath.UTF8String, nullptr);
+                    }
+                }
+            }
+
             NSArray* savedPrompts = [[NSUserDefaults standardUserDefaults] arrayForKey:@"MagentaRT_Prompts"];
 
             // Restore persisted advanced controls (buffer size, temperature, etc.)

--- a/magenta_rt/cli/mlx_commands.py
+++ b/magenta_rt/cli/mlx_commands.py
@@ -153,11 +153,11 @@ def export_spectrostream_cmd(output, checkpoint):
         codes = ss.waveform_to_codes_layer.layer(x)
         return codes.values
 
-    # Dummy waveform for tracing: 1 batch, 60 seconds at 48 kHz, stereo.
+    # Dummy waveform for tracing: 1 batch, 28 seconds at 48 kHz, stereo.
     #
     # We've observed that when performing continuation with low
     # CFG-MusicCoCa, low temperature, and small top-k (intending to strictly
-    # imitate the prefill context), a longer prefill (up to 60s) tends to
+    # imitate the prefill context), a longer prefill (up to 28 seconds) tends to
     # yield better continuation quality, even beyond the model's strict
     # receptive field (~19.7 s). To test this more concretely, try
     # `examples/hello_mrt2`.
@@ -166,7 +166,7 @@ def export_spectrostream_cmd(output, checkpoint):
     # (`MLXEngine::Impl::prefill_state` uses 25/25 for the mrt2_base STFT
     # config; different SpectroStream hyperparameters could shift the
     # head/tail transient zones).
-    dummy_waveform = mx.zeros((1, 48_000 * 60, 2), dtype=mx.float32)
+    dummy_waveform = mx.zeros((1, 48_000 * 28, 2), dtype=mx.float32)
 
     os.makedirs(os.path.dirname(output), exist_ok=True)
     mx.export_function(output, spectrostream_encode, dummy_waveform)


### PR DESCRIPTION
## Related Issues

- The SS encoder was not loaded when the LM is auto loaded
- the SS encoder in release accepts 28s input audio

## Local Pytests

> [!NOTE]
> Use `mrt models init` to download the necessary resources. Then use `mrt checkpoints download` to download `mrt2_small.safetensors` and `mrt2_base.safetensors`

I ran
```bash
mrt jax generate --model=mrt2_small
mrt mlx generate --model=mrt2_small
mrt mlx generate --model=mrt2_small --no-mlxfn --bits=8

pytest -s tests/test_musiccoca.py
pytest -s tests/test_prefill_correctness.py

python scripts/generate_test_reference.py
pytest -s tests/test_bitlevel_parity.py
```
and observed the following output:
```
all passed.
```

## Benchmark Regression Test

I ran
```bash
python scripts/bench_track.py
python scripts/bench_show.py --samples
```
and observed the following output:
```
2026-06-07T11:28:13 mrt2_small_int8_rvq12_cfgs0_260607_ca3b8e9      ca3b8e9    11.3   11.3   11.5   11.6   88.2  ✅ WITHIN BUDGET
                      ↳ [M4 Pro]
                      L: [-0.01214600, -0.01123047, -0.01174927, -0.01290894, -0.01229858, -0.01040649, -0.01046753, -0.01254272, -0.01406860, -0.01489258]
                      R: [-0.01068115, -0.00979614, -0.01040649, -0.01205444, -0.01242065, -0.01083374, -0.01028442, -0.01165771, -0.01266479, -0.01324463]
```
