### PR TITLE
Reuse the HuggingFace cache for model assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ mrt models download
 mrt mlx generate --prompt "disco funk" --duration 4.0 --model=mrt2_base
 ```
 
+> Already have the weights from `hf download google/magenta-realtime-2`? They're reused
+> automatically from the HuggingFace cache — you can skip the download commands. To make
+> the `mrt` CLI populate that shared cache instead of `~/Documents/Magenta/`, add
+> `--use-hf-cache`. See [docs/models.md](docs/models.md#reusing-the-huggingface-cache).
+
 ### Python Development
 
 For local development, clone the repo instead of installing from PyPI:

--- a/docs/models.md
+++ b/docs/models.md
@@ -64,6 +64,27 @@ Expected directory layout:
     └── <model_name>.safetensors
 ```
 
+### Reusing the HuggingFace cache
+
+Assets are loaded with `~/Documents/Magenta/magenta-rt-v2/` taking precedence, then
+the standard HuggingFace cache (`~/.cache/huggingface/hub`) as a fallback. If you have
+already pulled the repo with `hf download google/magenta-realtime-2`, those files are
+reused automatically at load time — no re-download — so you don't have to run the
+`mrt` download commands at all.
+
+To have the `mrt` CLI populate (and reuse) that shared cache instead of the
+`magenta-rt-v2/` folder, pass `--use-hf-cache` (or set `MAGENTA_RT_USE_HF_CACHE=1`):
+
+```bash
+mrt models init --use-hf-cache
+mrt models download --use-hf-cache
+```
+
+The default behavior is unchanged (downloads into `magenta-rt-v2/`). The flag applies to
+the HuggingFace source only; the GCS source always downloads into the local folder.
+`MAGENTA_HOME` (and `--download-path`) still override locations, and outputs, locally
+exported `.mlxfn` models, and GCS downloads always live under `magenta-rt-v2/`.
+
 ## Download raw checkpoints
 
 One may find raw model checkpoints (safetensors before exporting to mlxfn) useful for research purposes. Thus we offer them via `mrt checkpoints download` CLI.

--- a/magenta_rt/cli/models_commands.py
+++ b/magenta_rt/cli/models_commands.py
@@ -48,13 +48,19 @@ from magenta_rt import paths
 _DEFAULT_SOURCE = os.environ.get('MAGENTA_RT_DOWNLOAD_SOURCE', 'hf')
 _HF_TOKEN = os.environ.get('HF_TOKEN', None)
 
+# Opt-in: warm/reuse the global HuggingFace cache instead of downloading into the
+# local MAGENTA_HOME folder. Default off to preserve current behavior.
+_DEFAULT_USE_HF_CACHE = (
+    os.environ.get('MAGENTA_RT_USE_HF_CACHE', '').lower() in ('1', 'true', 'yes')
+)
+
 # GCS settings
 _GCP_PROJECT = "brain-magenta"
 _GCS_BUCKET = "magenta-rt-public"
 _GCS_CHECKPOINTS_PREFIX = "magenta-rt-2"
 
-# HuggingFace settings
-_HF_REPO_NAME = 'google/magenta-realtime-2'
+# HuggingFace settings (single source of truth shared with the asset resolver).
+_HF_REPO_NAME = paths.HF_REPO_ID
 
 # Resources synced by `mrt models init`.
 # Paths are the same in both GCS (under _GCS_CHECKPOINTS_PREFIX) and HF repo.
@@ -189,17 +195,21 @@ def _list_gcs_dirs(gcs_prefix: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _download_hf(repo_path: str, local_path: Path) -> None:
+def _download_hf(repo_path: str, local_path: Path, *, use_cache: bool = False) -> None:
     """Download a directory from HuggingFace repo to a local directory.
 
     Args:
         repo_path: Path within the HF repo (e.g. "resources/musiccoca").
         local_path: Local destination that should mirror repo_path
             (e.g. ~/Documents/Magenta/magenta-rt-v2/resources/musiccoca).
+        use_cache: If True, populate the global HuggingFace cache instead of
+            writing into ``local_path`` (so an existing cache is reused and the
+            files are shared with `hf download`).
     """
     import huggingface_hub  # noqa: E402
 
-    local_path.mkdir(parents=True, exist_ok=True)
+    if not use_cache:
+        local_path.mkdir(parents=True, exist_ok=True)
 
     # hf_hub_download saves to local_dir/filename.  Since filename is the
     # full repo-relative path (e.g. "resources/musiccoca/file.bin"),
@@ -231,14 +241,21 @@ def _download_hf(repo_path: str, local_path: Path) -> None:
                 prefix_with_slash = repo_path
             relative_path = rel_to_repo[len(prefix_with_slash):]
 
-            click.echo(f"  Downloading {relative_path} …")
-
-            huggingface_hub.hf_hub_download(
-                repo_id=_HF_REPO_NAME,
-                filename=rel_to_repo,
-                local_dir=str(local_dir),
-                token=_HF_TOKEN,
-            )
+            if use_cache:
+                click.echo(f"  Caching {relative_path} …")
+                huggingface_hub.hf_hub_download(
+                    repo_id=_HF_REPO_NAME,
+                    filename=rel_to_repo,
+                    token=_HF_TOKEN,
+                )
+            else:
+                click.echo(f"  Downloading {relative_path} …")
+                huggingface_hub.hf_hub_download(
+                    repo_id=_HF_REPO_NAME,
+                    filename=rel_to_repo,
+                    local_dir=str(local_dir),
+                    token=_HF_TOKEN,
+                )
 
     except Exception as e:
         click.echo(
@@ -280,12 +297,32 @@ def _list_hf_dirs(repo_path: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _download(source: str, remote_path: str, local_path: Path) -> None:
+def _cache_has(filename: str) -> bool:
+    """True if ``filename`` from the HF repo is already in the global cache."""
+    try:
+        import huggingface_hub  # noqa: E402
+
+        return (
+            huggingface_hub.try_to_load_from_cache(_HF_REPO_NAME, filename)
+            is not None
+        )
+    except Exception:
+        return False
+
+
+def _download(
+    source: str, remote_path: str, local_path: Path, *, use_cache: bool = False
+) -> None:
     """Download from either GCS or HuggingFace."""
     if source == "gcs":
+        if use_cache:
+            click.echo(
+                "  Note: --use-hf-cache has no effect for the GCS source; "
+                "downloading into the local folder."
+            )
         _download_gcs(_gcs_uri(remote_path), local_path)
     elif source == "hf":
-        _download_hf(remote_path, local_path)
+        _download_hf(remote_path, local_path, use_cache=use_cache)
     else:
         click.echo(
             click.style("Error: ", fg="red", bold=True)
@@ -406,6 +443,19 @@ _source_option = click.option(
 )
 
 
+_use_hf_cache_option = click.option(
+    "--use-hf-cache/--no-use-hf-cache",
+    default=_DEFAULT_USE_HF_CACHE,
+    show_default=True,
+    help=(
+        "Reuse/populate the global HuggingFace cache instead of writing into the "
+        "local folder (HuggingFace source only). Lets assets be shared with "
+        "`hf download` and avoids re-downloading. Default off (env: "
+        "MAGENTA_RT_USE_HF_CACHE)."
+    ),
+)
+
+
 @models.command()
 @click.option(
     "--download-path",
@@ -415,14 +465,17 @@ _source_option = click.option(
     help="Root directory for downloaded assets.",
 )
 @_source_option
-def init(download_path, source):
+@_use_hf_cache_option
+def init(download_path, source, use_hf_cache):
     """Fetch all shared model resources (musiccoca, spectrostream)."""
     download_path = Path(download_path)
     source_label = "HuggingFace" if source == "hf" else "GCS"
+    use_cache = use_hf_cache and source == "hf"
+    dest_label = "HuggingFace cache" if use_cache else str(download_path)
 
     click.echo(
         click.style("Initializing model resources", bold=True)
-        + f" from {source_label} → {download_path}"
+        + f" from {source_label} → {dest_label}"
     )
 
     for remote_suffix, local_subdir in _INIT_RESOURCES:
@@ -432,7 +485,7 @@ def init(download_path, source):
             remote_path = remote_suffix
         dst = download_path / local_subdir
         click.echo(f"\n📦 Downloading {click.style(local_subdir, fg='cyan')} …")
-        _download(source, remote_path, dst)
+        _download(source, remote_path, dst, use_cache=use_cache)
 
     click.echo(click.style("\n✓ Init complete.", fg="green", bold=True))
 
@@ -447,7 +500,8 @@ def init(download_path, source):
     help="Root directory for downloaded assets.",
 )
 @_source_option
-def download(name, download_path, source):
+@_use_hf_cache_option
+def download(name, download_path, source, use_hf_cache):
     """Download an exported model by NAME.
 
     If NAME is omitted an interactive picker lists all available models.
@@ -455,6 +509,7 @@ def download(name, download_path, source):
     download_path = Path(download_path)
     models_dir = download_path / "models"
     source_label = "HuggingFace" if source == "hf" else "GCS"
+    use_cache = use_hf_cache and source == "hf"
 
     if name is None:
         # Interactive selection
@@ -465,11 +520,16 @@ def download(name, download_path, source):
             click.echo(f"No models found on {source_label}.")
             return
 
-        # Determine which models are already downloaded locally.
+        # Determine which models are already downloaded locally (or cached).
         downloaded = set()
         if models_dir.exists():
             downloaded = {
                 p.name for p in models_dir.iterdir() if p.is_dir()
+            }
+        if use_cache:
+            downloaded |= {
+                n for n in available
+                if _cache_has(f"{_MODELS_SUBDIR}/{n}/{n}.mlxfn")
             }
 
         name = _interactive_select(available, downloaded)
@@ -482,11 +542,12 @@ def download(name, download_path, source):
     else:
         remote_path = f"{_MODELS_SUBDIR}/{name}"
     dst = models_dir / name
+    dest_label = "HuggingFace cache" if use_cache else str(dst)
     click.echo(
         f"\n📦 Downloading model {click.style(name, fg='cyan')}"
-        f" from {source_label} → {dst} …"
+        f" from {source_label} → {dest_label} …"
     )
-    _download(source, remote_path, dst)
+    _download(source, remote_path, dst, use_cache=use_cache)
     click.echo(click.style(f"\n✓ Model '{name}' downloaded.", fg="green", bold=True))
 
 
@@ -510,7 +571,8 @@ def checkpoints():
     help="Root directory for downloaded assets.",
 )
 @_source_option
-def download(name, download_path, source):
+@_use_hf_cache_option
+def download(name, download_path, source, use_hf_cache):
     """Download a raw model checkpoint by NAME.
 
     If NAME is omitted an interactive picker lists all available checkpoints.
@@ -518,6 +580,7 @@ def download(name, download_path, source):
     download_path = Path(download_path)
     ckpt_dir = download_path / "checkpoints"
     source_label = "HuggingFace" if source == "hf" else "GCS"
+    use_cache = use_hf_cache and source == "hf"
 
     if name is None:
         # Interactive selection
@@ -528,11 +591,16 @@ def download(name, download_path, source):
             click.echo(f"No checkpoints found on {source_label}.")
             return
 
-        # Determine which checkpoints are already downloaded locally.
+        # Determine which checkpoints are already downloaded locally (or cached).
         downloaded = set()
         if ckpt_dir.exists():
             downloaded = {
                 p.name for p in ckpt_dir.iterdir() if p.is_file()
+            }
+        if use_cache:
+            downloaded |= {
+                n for n in available
+                if _cache_has(f"{_CHECKPOINTS_SUBDIR}/{n}")
             }
 
         name = _interactive_select(available, downloaded)
@@ -545,16 +613,18 @@ def download(name, download_path, source):
     if not name.endswith(".safetensors"):
         name = f"{name}.safetensors"
 
-    # Download the single checkpoint file.
-    ckpt_dir.mkdir(parents=True, exist_ok=True)
-    local_file = ckpt_dir / name
-
-    click.echo(
-        f"\n📦 Downloading checkpoint {click.style(name, fg='cyan')}"
-        f" from {source_label} → {local_file} …"
-    )
-
     if source == "gcs":
+        if use_hf_cache:
+            click.echo(
+                "  Note: --use-hf-cache has no effect for the GCS source; "
+                "downloading into the local folder."
+            )
+        ckpt_dir.mkdir(parents=True, exist_ok=True)
+        local_file = ckpt_dir / name
+        click.echo(
+            f"\n📦 Downloading checkpoint {click.style(name, fg='cyan')}"
+            f" from {source_label} → {local_file} …"
+        )
         from google.cloud import storage  # noqa: E402
         client = _get_storage_client()
         bucket = client.bucket(_GCS_BUCKET)
@@ -564,12 +634,19 @@ def download(name, download_path, source):
         blob.download_to_filename(str(temp_file))
         temp_file.replace(local_file)
     else:
+        dest_label = "HuggingFace cache" if use_cache else str(ckpt_dir / name)
+        click.echo(
+            f"\n📦 Downloading checkpoint {click.style(name, fg='cyan')}"
+            f" from {source_label} → {dest_label} …"
+        )
         import huggingface_hub  # noqa: E402
-        huggingface_hub.hf_hub_download(
+        hf_kwargs = dict(
             repo_id=_HF_REPO_NAME,
             filename=f"{_CHECKPOINTS_SUBDIR}/{name}",
-            local_dir=str(download_path),
             token=_HF_TOKEN,
         )
+        if not use_cache:
+            hf_kwargs["local_dir"] = str(download_path)
+        huggingface_hub.hf_hub_download(**hf_kwargs)
 
     click.echo(click.style(f"\n✓ Checkpoint '{name}' downloaded.", fg="green", bold=True))

--- a/magenta_rt/jax/system.py
+++ b/magenta_rt/jax/system.py
@@ -234,7 +234,7 @@ class MagentaRT2System:
         )
       checkpoint = _CHECKPOINT_REGISTRY[size]
 
-    checkpoint_path = paths.checkpoints_dir() / checkpoint
+    checkpoint_path = paths.resolve_checkpoint(checkpoint)
     logger.info('Loading checkpoint: %s', checkpoint_path)
     self._params = _load_jax_weights(checkpoint_path)
 

--- a/magenta_rt/mlx/spectrostream/load_weights.py
+++ b/magenta_rt/mlx/spectrostream/load_weights.py
@@ -413,8 +413,20 @@ def load_spectrostream_weights(
       for k in unupdated_dec:
         print(f"  NOT UPDATED: {'.'.join(k)}")
 
-  # SpectroStream encoder (conv layers)
-  encoder_path = os.path.join(os.path.dirname(checkpoint_path), 'encoder.safetensors')
+  # SpectroStream encoder (conv layers). Prefer a sibling of the checkpoint (the
+  # historical co-located layout); otherwise fall back to the resolved
+  # SpectroStream resource dir (MAGENTA_HOME or the HF cache). The import is lazy
+  # and guarded so this module stays self-contained / standalone-importable.
+  encoder_path = os.path.join(os.path.dirname(str(checkpoint_path)), 'encoder.safetensors')
+  if not os.path.exists(encoder_path):
+    try:
+      from magenta_rt import paths  # noqa: E402
+
+      resolved = paths.resolve_spectrostream_dir() / 'encoder.safetensors'
+      if resolved.exists():
+        encoder_path = str(resolved)
+    except Exception:
+      pass
   if os.path.exists(encoder_path):
     print('  Loading SpectroStream encoder...')
     # Materialize all deferred conv layers by running a dummy step for encoder.

--- a/magenta_rt/mlx/system.py
+++ b/magenta_rt/mlx/system.py
@@ -232,7 +232,7 @@ class MagentaRT2System:
         )
       checkpoint = _CHECKPOINT_REGISTRY[size]
 
-    checkpoint_path = paths.checkpoints_dir() / checkpoint
+    checkpoint_path = paths.resolve_checkpoint(checkpoint)
     logger.info('Loading checkpoint: %s', checkpoint_path)
     load_weights(
         self._sampler, checkpoint_path,
@@ -529,7 +529,7 @@ class MagentaRT2SystemMlxfn:
       warmup_steps: Number of warmup inference steps.
     """
     model_name = size or paths.DEFAULT_MODEL_NAME
-    model_path = paths.models_dir() / model_name
+    model_path = paths.resolve_model_dir(model_name)
 
     basename = model_path.name
     mlxfn_path = str(model_path / f'{basename}.mlxfn')

--- a/magenta_rt/musiccoca.py
+++ b/magenta_rt/musiccoca.py
@@ -368,7 +368,7 @@ class MusicCoCa(MusicCoCaBase):
         )
     )
     self._resource_dir = pathlib.Path(
-        resource_dir or paths.musiccoca_dir()
+        resource_dir or paths.resolve_musiccoca_dir()
     )
     if not lazy:
       self._vocab  # pylint: disable=pointless-statement

--- a/magenta_rt/paths.py
+++ b/magenta_rt/paths.py
@@ -33,6 +33,15 @@ _MAGENTA_HOME = _MAGENTA_BASE / "magenta-rt-v2"
 DEFAULT_MODEL_NAME = "mrt2_base"
 DEFAULT_CHECKPOINT = "mrt2_base.safetensors"
 
+# HuggingFace repo that mirrors the MAGENTA_HOME layout (resources/, models/,
+# checkpoints/). Single source of truth, shared with the download CLI.
+HF_REPO_ID = "google/magenta-realtime-2"
+
+
+def _hf_token() -> "Union[str, None]":
+    """HuggingFace token from the environment, if set."""
+    return os.environ.get("HF_TOKEN")
+
 
 def magenta_home() -> pathlib.Path:
     """Returns the magenta home directory (default: ~/Documents/Magenta/magenta-rt-v2)."""
@@ -94,27 +103,128 @@ def checkpoints_dir() -> pathlib.Path:
 def resolve_checkpoint(filename: str) -> pathlib.Path:
     """Resolve a checkpoint file path.
 
-    First check if literal filepath exists; fallback to ~/Documents/Magenta/magenta-rt-v2/checkpoints/<filename>.
+    Resolution order:
+      1. ``filename`` as a literal filepath, if it exists.
+      2. ``<MAGENTA_HOME>/checkpoints/<filename>``, if it exists.
+      3. The same file reused from the global HuggingFace cache (no network
+         fetch — an already-populated cache from ``hf download`` or
+         ``mrt checkpoints download --use-hf-cache`` is picked up here).
 
     Args:
-        filename: Checkpoint filename ending in `.safetensors`
+        filename: Checkpoint filename ending in `.safetensors`, or a literal path.
 
     Returns:
-        Path to the checkpoint file (may not exist yet).
+        Path to the checkpoint file. Falls back to the MAGENTA_HOME path (which
+        may not exist yet) when the asset is neither local nor cached.
     """
     if os.path.isfile(filename):
-        return filename
-    return checkpoints_dir() / filename
+        return pathlib.Path(filename)
+    # NB: build the candidate path directly (do not call checkpoints_dir(), which
+    # mkdir's as a side effect) — resolution must not create dirs, so a cache hit
+    # leaves MAGENTA_HOME untouched.
+    local = _MAGENTA_HOME / "checkpoints" / filename
+    if local.exists():
+        return local
+    cached = _resolve_from_cache(f"checkpoints/{filename}", is_dir=False)
+    return cached if cached is not None else local
 
 # ---------------------------------------------------------------------------
-# Path resolution without fallbacks — everything in ~/Documents/Magenta/magenta-rt-v2)
+# Asset resolution — MAGENTA_HOME layout first, global HuggingFace cache fallback
 # ---------------------------------------------------------------------------
+#
+# Reads resolve through the global HF cache so an asset already fetched (e.g. via
+# `hf download google/magenta-realtime-2` or `mrt models download --use-hf-cache`)
+# is reused instead of re-downloaded. The MAGENTA_HOME layout always wins, so
+# local exports / GCS downloads / user overrides take precedence. Resolution is
+# cache-reuse only (no network fetch) unless `allow_download=True`.
+
+
+def _resolve_from_cache(
+    repo_relative: str, *, is_dir: bool, allow_download: bool = False
+) -> "Union[pathlib.Path, None]":
+    """Resolve a repo-relative asset from the global HF cache.
+
+    Returns the cached path, or None if it is not cached (and not downloaded).
+    """
+    import huggingface_hub  # lazy: keep paths.py import-light / offline-safe
+
+    try:
+        if is_dir:
+            root = huggingface_hub.snapshot_download(
+                repo_id=HF_REPO_ID,
+                allow_patterns=f"{repo_relative}/*",
+                token=_hf_token(),
+                local_files_only=not allow_download,
+            )
+            resolved = pathlib.Path(root) / repo_relative
+            return resolved if resolved.exists() else None
+        return pathlib.Path(
+            huggingface_hub.hf_hub_download(
+                repo_id=HF_REPO_ID,
+                filename=repo_relative,
+                token=_hf_token(),
+                local_files_only=not allow_download,
+            )
+        )
+    except Exception:
+        # Not in the cache (local_files_only) or unavailable from the hub.
+        return None
+
+
+def resolve_asset(
+    repo_relative: str, *, is_dir: bool = False, allow_download: bool = False
+) -> pathlib.Path:
+    """Resolve a model asset: MAGENTA_HOME layout first, else the HF cache.
+
+    Args:
+        repo_relative: Path mirroring the HF repo layout, e.g.
+            ``"resources/musiccoca"`` or ``"checkpoints/mrt2_base.safetensors"``.
+        is_dir: True to resolve a directory of files, False for a single file.
+        allow_download: If True, fetch from the hub when missing from the cache;
+            otherwise reuse the cache only (the default for load paths).
+
+    Returns:
+        An existing local path to the asset.
+
+    Raises:
+        FileNotFoundError: if the asset is neither under MAGENTA_HOME nor cached.
+    """
+    local = _MAGENTA_HOME / repo_relative
+    if local.exists():
+        return local
+    cached = _resolve_from_cache(
+        repo_relative, is_dir=is_dir, allow_download=allow_download
+    )
+    if cached is not None:
+        return cached
+    raise FileNotFoundError(
+        f"Could not find '{repo_relative}'. Looked in '{local}' and the global "
+        f"HuggingFace cache for repo '{HF_REPO_ID}'. Download it with "
+        f"`mrt models download` (add `--use-hf-cache` to populate the HF cache), "
+        f"or `hf download {HF_REPO_ID}`."
+    )
+
+
+def resolve_musiccoca_dir() -> pathlib.Path:
+    """MusicCoCa resource directory, resolved from MAGENTA_HOME or the HF cache."""
+    return resolve_asset("resources/musiccoca", is_dir=True)
+
+
+def resolve_spectrostream_dir() -> pathlib.Path:
+    """SpectroStream resource directory, resolved from MAGENTA_HOME or the HF cache."""
+    return resolve_asset("resources/spectrostream", is_dir=True)
+
+
+def resolve_model_dir(name: str) -> pathlib.Path:
+    """Exported `.mlxfn` model directory, resolved from MAGENTA_HOME or the HF cache."""
+    return resolve_asset(f"models/{name}", is_dir=True)
+
 
 def resolve_encoder_weights() -> pathlib.Path:
-    """Returns ~/Documents/Magenta/magenta-rt-v2/resources/spectrostream/encoder.safetensors."""
-    return spectrostream_dir() / "encoder.safetensors"
+    """SpectroStream encoder.safetensors, resolved from MAGENTA_HOME or the HF cache."""
+    return resolve_spectrostream_dir() / "encoder.safetensors"
 
 
 def resolve_decoder_weights() -> pathlib.Path:
-    """Returns ~/Documents/Magenta/magenta-rt-v2/resources/spectrostream/decoder.safetensors."""
-    return spectrostream_dir() / "decoder.safetensors"
+    """SpectroStream decoder.safetensors, resolved from MAGENTA_HOME or the HF cache."""
+    return resolve_spectrostream_dir() / "decoder.safetensors"


### PR DESCRIPTION
# Reuse the HuggingFace cache for model assets

Model assets (musiccoca + spectrostream resources, exported .mlxfn models, raw checkpoints) were always downloaded into ~/Documents/Magenta/magenta-rt-v2/ via hf_hub_download(local_dir=...), which never consults the global HF cache. A repo already pulled with `hf download google/magenta-realtime-2` was re-downloaded over the network, and assets were duplicated on disk.

Resolve assets MAGENTA_HOME-first, then the global HF cache:

- paths.py: add resolve_asset() plus resolve_musiccoca_dir / resolve_spectrostream_dir / resolve_model_dir helpers. The local MAGENTA_HOME layout always wins (so local exports, GCS downloads, and user overrides take precedence); otherwise the asset is served from the global HF cache. Load paths reuse the cache only (local_files_only) — no network fetch at load time — so default behavior is unchanged except that an existing `hf download` is now picked up. A missing asset raises a clear FileNotFoundError pointing at both locations.

- Route load sites through the resolver: musiccoca.py, mlx/system.py (mlxfn model dir + checkpoint), jax/system.py (checkpoint).

- mlx/spectrostream/load_weights.py: when encoder.safetensors is not a sibling of the checkpoint (e.g. assets live in the HF cache, where the checkpoint and resources sit in different repo subdirs), fall back to the resolved spectrostream resource dir. Guarded lazy import keeps the module standalone.

- resolve_checkpoint(): build the candidate path directly instead of via checkpoints_dir(), which mkdir's as a side effect. Resolution no longer creates directories, so a cache hit leaves MAGENTA_HOME untouched.

CLI (opt-in, default behavior unchanged):

- Add `--use-hf-cache` (env: `MAGENTA_RT_USE_HF_CACHE`) to `mrt models init`, `mrt models download`, and `mrt checkpoints download`. When set, downloads populate/reuse the global HF cache (omit local_dir) and the interactive picker's checkmarks consult the cache. The flag is HuggingFace-only; the GCS source and `--download-path` are unaffected.

Docs: note cache reuse and the flag in `README.md` and `docs/models.md`.

## Related Issues

* None filed. Builds on #45 (fixes the `--download-path` readability probe). Both touch the `--download-path` options in `models_commands.py`, so I'll rebase this branch after #45 merges (adopt the shared `_download_path_option`, keep `--use-hf-cache`).

## Local Pytests

> [!NOTE]
> This change reroutes *where* assets load from (MAGENTA_HOME → global HF cache); it does not alter model math or sampling. Validation below focuses on (a) cache reuse and (b) that both load paths still load correctly from the cache. The numeric-parity/bitlevel tests are gated on a generated reference in this environment and skip; they're included to show no regressions. Paths anonymized.

I ran
```bash
# 1. Warm the cache (first run downloads into ~/.cache/huggingface), then re-run = cache hit
mrt models init --use-hf-cache
Initializing model resources from HuggingFace → HuggingFace cache

📦 Downloading resources/musiccoca …
  Caching audio_preprocessor.tflite …
resources/musiccoca/audio_preprocessor.t(…): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8.73M/8.73M [00:00<00:00, 14.8MB/s]
  Caching mapper.tflite …
resources/musiccoca/mapper.tflite: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 86.2M/86.2M [00:01<00:00, 61.4MB/s]
  Caching music_encoder.tflite …
resources/musiccoca/music_encoder.tflite: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 371M/371M [00:05<00:00, 66.5MB/s]
  Caching pretrained_vector_quantizer.tflite …
resources/musiccoca/pretrained_vector_qu(…): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 72.4M/72.4M [00:01<00:00, 51.5MB/s]
  Caching spm.model …
  Caching text_encoder.tflite …
resources/musiccoca/text_encoder.tflite: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 419M/419M [00:06<00:00, 64.2MB/s]

📦 Downloading resources/spectrostream …
  Caching decoder.safetensors …
resources/spectrostream/decoder.safetens(…): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 210M/210M [00:04<00:00, 52.0MB/s]
  Caching encoder.safetensors …
resources/spectrostream/encoder.safetens(…): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 37.0M/37.0M [00:01<00:00, 27.8MB/s]
  Caching quantizer.safetensors …
resources/spectrostream/quantizer.safete(…): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 67.1M/67.1M [00:01<00:00, 37.4MB/s]
  Caching spectrostream_encoder.mlxfn …
resources/spectrostream/spectrostream_en(…): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 104M/104M [00:01<00:00, 57.1MB/s]

✓ Init complete.


time mrt models init --use-hf-cache

Initializing model resources from HuggingFace → HuggingFace cache

📦 Downloading resources/musiccoca …
  Caching audio_preprocessor.tflite …
  Caching mapper.tflite …
  Caching music_encoder.tflite …
  Caching pretrained_vector_quantizer.tflite …
  Caching spm.model …
  Caching text_encoder.tflite …

📦 Downloading resources/spectrostream …
  Caching decoder.safetensors …
  Caching encoder.safetensors …
  Caching quantizer.safetensors …
  Caching spectrostream_encoder.mlxfn …

✓ Init complete.


# 2. Confirm the custom folder stays clean (nothing written to ~/Documents)
ls -R ~/Documents/Magenta/magenta-rt-v2/ 2>/dev/null || echo "magenta-rt-v2 has no downloaded assets (as intended)" 
magenta-rt-v2 has no downloaded assets (as intended)

# 3. Pull a model into the cache and generate (default .mlxfn path)

mrt models download mrt2_small --use-hf-cache
📦 Downloading model mrt2_small from HuggingFace → HuggingFace cache …
  Caching mrt2_small.mlxfn …
  Caching mrt2_small_state.safetensors …

✓ Model 'mrt2_small' downloaded.


mrt mlx generate --prompt "disco funk" --duration 4.0 --model=mrt2_small
INFO:magenta_rt.mlx.system:Loading mlxfn: ~/.cache/huggingface/hub/models--google--magenta-realtime-2/snapshots/010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc/models/mrt2_small/mrt2_small.mlxfn
INFO:magenta_rt.mlx.system:Loaded 165 state arrays
INFO:magenta_rt.mlx.system:Warming up (5 steps)...
INFO:magenta_rt.mlx.system:Warm-up done (1.0s).
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
Generated 100 frames in 1.3s (78.4 steps/s, 12.8 ms/step)
Target: 25 steps/s, 40 ms/step for real-time
Saved to ~/Documents/Magenta/magenta-rt-v2/outputs/output_audio_mlx_mrt2_small.wav (4.0s of audio)


# 4. Exercise the Python (--no-mlxfn) path: checkpoint + SpectroStream encoder from cache

mrt checkpoints download mrt2_small.safetensors --use-hf-cache 
📦 Downloading checkpoint mrt2_small.safetensors from HuggingFace → HuggingFace cache …
checkpoints/mrt2_small.safetensors: 100%|██████████████████████████████████████████████████████████████████████████| 1.13G/1.13G [00:14<00:00, 77.7MB/s]

✓ Checkpoint 'mrt2_small.safetensors' downloaded.


mrt mlx generate --prompt "disco funk" --duration 4.0 --model=mrt2_small --no-mlxfn --bits=8

INFO:magenta_rt.mlx.system:Loading checkpoint: ~/.cache/huggingface/hub/models--google--magenta-realtime-2/snapshots/010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc/checkpoints/mrt2_small.safetensors
INFO:jax._src.xla_bridge:Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: dlopen(libtpu.so, 0x0001): tried: '/opt/homebrew/opt/ffmpeg/lib/libtpu.so' (no such file), 'libtpu.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibtpu.so' (no such file), '/usr/lib/libtpu.so' (no such file, not in dyld cache), 'libtpu.so' (no such file)
WARNING:root:Classifier free guidance scale(s) specified, but negative(s) not specified; using zeros as negatives.
INFO:magenta_rt.mlx.system:Quantizing to 8-bit (group_size=64).
INFO:magenta_rt.mlx.system:Warming up...
INFO:magenta_rt.mlx.system:Warm-up done (0.3s).
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
Materializing deferred layers...
Materialized ✓
Loading checkpoint: ~/.cache/huggingface/hub/models--google--magenta-realtime-2/snapshots/010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc/checkpoints/mrt2_small.safetensors
Loading encoder...
  Detected branched encoder embedding.
  Branched encoder embeddings loaded.
Loading decoder...
Loading temporal body (transformer)...
Loading depth body...
  Loaded depth_input_adapter weights.
Warning: 2 Depthformer parameters were NOT updated during loading.
  NOT UPDATED: decoder.embedder.layers.1._scale
  NOT UPDATED: sampler.decoder.embedder.layers.1._scale
Loading spectrostream...
  Loading quantizer embeddings...
  Loading SpectroStream decoder...
    SpectroStream decoder weights loaded.
  Loading SpectroStream encoder...
    SpectroStream encoder weights loaded.
Converting depthformer params to bfloat16...
Weight loading complete (11 groups loaded)
  Depthformer params:      229,732,614
  SpectroStream params:       61,713,666
  Total loaded params:     291,446,280
Generated 100 frames in 2.0s (50.9 steps/s, 19.6 ms/step)
Target: 25 steps/s, 40 ms/step for real-time
Saved to ~/Documents/Magenta/magenta-rt-v2/outputs/output_audio_mlx_mrt2_small.wav (4.0s of audio)

# 5. Parity suite
pytest -s tests/test_musiccoca.py tests/test_prefill_correctness.py tests/test_bitlevel_parity.py
```
and observed the following output:
```
# (2) custom folder untouched on cache hit:
magenta-rt-v2 has no downloaded assets (as intended)

# (3) default .mlxfn generate — model resolved from the HF cache:
INFO:magenta_rt.mlx.system:Loading mlxfn: ~/.cache/huggingface/hub/models--google--magenta-realtime-2/snapshots/<rev>/models/mrt2_small/mrt2_small.mlxfn
Generated 100 frames in 1.3s (78.4 steps/s, 12.8 ms/step)
Saved to ~/Documents/Magenta/magenta-rt-v2/outputs/output_audio_mlx_mrt2_small.wav (4.0s of audio)

# (4) --no-mlxfn generate — checkpoint AND SpectroStream encoder resolved from the HF cache:
INFO:magenta_rt.mlx.system:Loading checkpoint: ~/.cache/huggingface/hub/models--google--magenta-realtime-2/snapshots/<rev>/checkpoints/mrt2_small.safetensors
Loading spectrostream...
  Loading SpectroStream encoder...
    SpectroStream encoder weights loaded.
Weight loading complete (11 groups loaded)
Saved to ~/Documents/Magenta/magenta-rt-v2/outputs/output_audio_mlx_mrt2_small.wav (4.0s of audio)

# (5) parity suite — clean, no failures (parity/bitlevel tests skip without a generated reference):
======================================================= 3 passed, 21 skipped, 4 warnings in 2.59s =======================================================
```

## Benchmark Regression Test

N/A — this change only affects asset resolution (which directory weights are loaded from). It does not touch sampling, the model graph, or any performance-sensitive code path, so there is no benchmark surface to regress.