### PR TITLE
Fix: accept bare checkpoint name in `mrt checkpoints download`

### DIFF
--- a/magenta_rt/cli/models_commands.py
+++ b/magenta_rt/cli/models_commands.py
@@ -540,6 +540,11 @@ def download(name, download_path, source):
             click.echo("Cancelled.")
             return
 
+    # Accept a bare model name (e.g. "mrt2_small") as well as a full filename;
+    # checkpoints are always .safetensors, mirroring `mrt models download`.
+    if not name.endswith(".safetensors"):
+        name = f"{name}.safetensors"
+
     # Download the single checkpoint file.
     ckpt_dir.mkdir(parents=True, exist_ok=True)
     local_file = ckpt_dir / name


### PR DESCRIPTION
# Fix: accept bare checkpoint name in `mrt checkpoints download`

`mrt checkpoints download mrt2_small` built the HuggingFace path as `checkpoints/mrt2_small` (no extension), causing a 404 (`Entry Not Found`). Users had to pass the full `mrt2_small.safetensors`.

This appends `.safetensors` when the suffix is omitted, so a bare name works — matching `mrt models download`, and the behavior agreed on in the issue thread. A full filename stays idempotent, and the fix covers both the HuggingFace and GCS download paths. The interactive picker is unaffected (it already returns full filenames).

## Related Issues

* Fixes #47 

## Local Pytests

I ran
```bash
mrt checkpoints download mrt2_small                                                                      
```
and observed the following output:
```
📦 Downloading checkpoint mrt2_small.safetensors from HuggingFace → ~/Documents/Magenta/magenta-rt-v2/checkpoints/mrt2_small.safetensors …

✓ Checkpoint 'mrt2_small.safetensors' downloaded.
```

## Benchmark Regression Test

N/A - argument normalization only; no model or performance-sensitive code path is touched.
