### PR TITLE
Fix quantizer TFLite race between reset_state and async prompt encode

### DIFF
--- a/core/src/mlx_engine.cpp
+++ b/core/src/mlx_engine.cpp
@@ -199,6 +199,16 @@ struct MLXEngine::Impl {
 
   // --- MusicCoCa async token state ---
   mutable std::mutex musiccoca_mutex_;
+  // Serializes the *actual* quantizer TFLite invocation. The quantizer
+  // interpreter is a single stateful graph and is NOT thread-safe: two
+  // concurrent `TfLiteInterpreterInvoke`s corrupt its tensor arena, after
+  // which its internal GATHER node reads a stale index and fails with
+  // "gather index out of bounds" on every subsequent call. `quantize_embedding`
+  // is reached from both the background fetch thread (flag-guarded only) and
+  // the control-thread reblend (mutex+flag-guarded); this dedicated lock makes
+  // concurrent invocation impossible regardless of the flag state. It is never
+  // taken on the render/inference thread (generate_frame uses cached tokens).
+  std::mutex quantizer_invoke_mutex_;
   std::atomic<bool> is_musiccoca_fetching_{false};
   std::atomic<int> text_encoder_status_{
       0}; // 0=idle 1=fetching 2=success 3=error
@@ -1317,7 +1327,14 @@ void MLXEngine::Impl::reset_state() {
       add_log(err);
     }
   }
-  is_musiccoca_fetching_ = false;
+  // NOTE: do NOT clear is_musiccoca_fetching_ here. reset_state() runs on the
+  // inference thread (via RealtimeRunner::trigger_reset / sn_reseed), which can
+  // fire while a background fetch is mid-encode. That flag is owned by the
+  // fetch thread's RAII guard and doubles as the reblend concurrency gate;
+  // clearing it out from under an in-flight fetch used to let a control-thread
+  // reblend invoke the quantizer concurrently with the fetch -> arena
+  // corruption -> "gather index out of bounds" (GATHER node) on every
+  // subsequent frame. Let the fetch's guard clear it when it actually finishes.
 
   // Check if we have active prompts still loaded
   bool has_active_prompts = false;
@@ -1970,6 +1987,10 @@ bool MLXEngine::Impl::quantize_embedding(const float *embedding,
                                          std::vector<int> &out_tokens) {
   if (!quantizer_interpreter_)
     return false;
+
+  // Hold the invoke lock across the whole input-write / invoke / output-read
+  // sequence so no other thread can touch the quantizer graph mid-flight.
+  std::lock_guard<std::mutex> invoke_lock(quantizer_invoke_mutex_);
 
   TfLiteTensor *q_input =
       TfLiteInterpreterGetInputTensor(quantizer_interpreter_, 0);


### PR DESCRIPTION
Fixes a thread-safety bug where a state
  reset firing during an in-flight
  prompt encode permanently corrupts the
  MusicCoCa quantizer interpreter, after
  which its GATHER node fails with
  `gather index out of bounds` on every
  subsequent call until the process
  restarts.

  `quantize_embedding` is reached from
  both the background fetch thread
  (flag-guarded only) and the
  control-thread reblend. `reset_state()`
  used to unconditionally clear
  `is_musiccoca_fetching_` — a flag owned
  by the fetch thread's RAII guard —
  reblend invoke the single stateful
  quantizer interpreter concurrently with
  an in-flight fetch. Two concurrent
  `TfLiteInterpreterInvoke`s corrupt the
  interpreter's tensor arena; the damage
  is persistent because TFLite
  interpreters are not safe for
  concurrent invocation.

  This PR:
  1. Adds a dedicated
  `quantizer_invoke_mutex_` held across
  the entire input-write / invoke /
  output-read sequence in
  `quantize_embedding`, so concurrent
  invocation is structurally impossible
  regardless of flag state. It is never
  taken on the render/inference path
  (`generate_frame` uses cached tokens),
  so the realtime audio path is
  unaffected.
  2. Removes the flag clobber from
  `reset_state()`, letting the fetch
  thread's guard clear it when the encode
  actually finishes — so the flag always
  means what it says and reblends
  correctly skip during encodes.

  Single-file diff, comments explaining
  the invariant, no behavior change on
  the audio path.

  ## Related Issues

  * Fixes #80

  ## Testing

  This is a single-file concurrency fix
  confined to the non-realtime quantizer
  path (`quantize_embedding` /
  `reset_state`); the realtime
  `generate_frame` path is untouched. It
  was validated against the original
  repro (reseed-during-encode no longer
  produces the GATHER corruption) in a
  downstream macOS host built on
  `magentart::core`.

  I have not run the full local pytest /
  benchmark suite in this environment —
  happy to run any specific tests the
  maintainers would like to see before
  merge.