### PR TITLE
Add modularity for input and conditioning configuration in MRT2

### DIFF
--- a/core/src/benchmark/benchmark_mlxfn.cpp
+++ b/core/src/benchmark/benchmark_mlxfn.cpp
@@ -24,7 +24,7 @@
 //   --target benchmark_mlxfn -j10
 //
 // Run:
-//   ./benchmark_build/benchmark_mlxfn [model_dir] [num_steps] [num_cfgs]
+//   ./benchmark_build/benchmark_mlxfn [model_dir] [num_steps]
 
 #include <mlx/mlx.h>
 
@@ -184,8 +184,7 @@ static std::pair<mx::array, std::vector<mx::array>> run_step(
         &fn,
     const mx::array &cond, float temperature, int top_k, float cfg_musiccoca,
     float cfg_notes, float cfg_drums, const std::vector<mx::array> &neg_arrays,
-    const std::vector<mx::array> &state, int dynamic_rvq_depth,
-    int num_cfgs) {
+    const std::vector<mx::array> &state, int dynamic_rvq_depth) {
   std::vector<mx::array> args;
   args.push_back(cond);
   args.push_back(mx::array({temperature}));
@@ -193,10 +192,7 @@ static std::pair<mx::array, std::vector<mx::array>> run_step(
   args.push_back(mx::array({cfg_musiccoca}));
   args.push_back(mx::array({cfg_notes}));
   args.push_back(mx::array({cfg_drums}));
-  // Only include negative conditioning arrays when CFGs are enabled.
-  for (int i = 0; i < num_cfgs && i < static_cast<int>(neg_arrays.size()); ++i) {
-    args.push_back(neg_arrays[i]);
-  }
+  args.insert(args.end(), neg_arrays.begin(), neg_arrays.end());
   args.push_back(
       mx::zeros({1, 0, dynamic_rvq_depth}, mx::int32)); // forced_tokens
   args.insert(args.end(), state.begin(), state.end());
@@ -210,10 +206,9 @@ static std::pair<mx::array, std::vector<mx::array>> run_step(
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 int main(int argc, char *argv[]) {
-  // Parse arguments: benchmark_mlxfn [model_dir] [num_steps] [num_cfgs]
+  // Parse arguments: benchmark_mlxfn [model_dir] [num_steps]
   std::string model_dir = "resources";
   int num_steps = kDefaultNumSteps;
-  int num_cfgs = 2; // default: musiccoca + notes
 
   // Scan for positional args
   std::vector<std::string> positional;
@@ -225,8 +220,6 @@ int main(int argc, char *argv[]) {
     model_dir = positional[0];
   if (positional.size() >= 2)
     num_steps = std::atoi(positional[1].c_str());
-  if (positional.size() >= 3)
-    num_cfgs = std::atoi(positional[2].c_str());
 
   // Strip trailing slashes
   while (!model_dir.empty() && model_dir.back() == '/')
@@ -247,7 +240,6 @@ int main(int argc, char *argv[]) {
   printf("  Model:       %s\n", mlxfn_path.c_str());
   printf("  State:       %s\n", state_path.c_str());
   printf("  Num steps:   %d\n", num_steps);
-  printf("  Num CFGs:    %d\n", num_cfgs);
   printf("───────────────────────────────────────────────────────────────\n\n");
 
   // ── Load model ──────────────────────────────────────────────────────
@@ -277,9 +269,7 @@ int main(int argc, char *argv[]) {
       dynamic_rvq_depth = shape[2];
     }
   }
-  printf("       ✓ Deduced dynamic RVQ depth: %d\n", dynamic_rvq_depth);
-
-  printf("       ✓ Using num_cfgs: %d\n\n", num_cfgs);
+  printf("       ✓ Deduced dynamic RVQ depth: %d\n\n", dynamic_rvq_depth);
 
   // ── Build conditioning input ────────────────────────────────────────
   auto cond = make_cond_input();
@@ -291,7 +281,7 @@ int main(int argc, char *argv[]) {
     auto [diag_audio, diag_state] =
         run_step(compiled_fn, cond, kDefaultTemperature, kDefaultTopK,
                  kDefaultCfgMusicCoCa, kDefaultCfgNotes, kDefaultCfgDrums,
-                 neg_arrays, initial_state, dynamic_rvq_depth, num_cfgs);
+                 neg_arrays, initial_state, dynamic_rvq_depth);
     mx::eval(diag_audio);
 
     // Print shape and dtype
@@ -337,7 +327,7 @@ int main(int argc, char *argv[]) {
     auto [audio, new_state] =
         run_step(compiled_fn, cond, kDefaultTemperature, kDefaultTopK,
                  kDefaultCfgMusicCoCa, kDefaultCfgNotes, kDefaultCfgDrums,
-                 neg_arrays, state, dynamic_rvq_depth, num_cfgs);
+                 neg_arrays, state, dynamic_rvq_depth);
     mx::eval(audio);
     mx::eval(new_state);
     state = std::move(new_state);
@@ -364,7 +354,7 @@ int main(int argc, char *argv[]) {
     auto [audio, new_state] =
         run_step(compiled_fn, cond, kDefaultTemperature, kDefaultTopK,
                  kDefaultCfgMusicCoCa, kDefaultCfgNotes, kDefaultCfgDrums,
-                 neg_arrays, state, dynamic_rvq_depth, num_cfgs);
+                 neg_arrays, state, dynamic_rvq_depth);
     mx::eval(audio);
     mx::eval(new_state);
 

--- a/core/src/benchmark/benchmark_mlxfn.cpp
+++ b/core/src/benchmark/benchmark_mlxfn.cpp
@@ -19,11 +19,12 @@
 // inference steps to measure per-step latency.
 //
 // Build:
-//   cmake benchmark -B benchmark_build && cmake --build benchmark_build
+//   cmake core/src/benchmark -B benchmark_build && cmake --build
+//   benchmark_build
 //   --target benchmark_mlxfn -j10
 //
 // Run:
-//   ./benchmark_build/benchmark_mlxfn [model_dir] [num_steps]
+//   ./benchmark_build/benchmark_mlxfn [model_dir] [num_steps] [num_cfgs]
 
 #include <mlx/mlx.h>
 
@@ -183,7 +184,8 @@ static std::pair<mx::array, std::vector<mx::array>> run_step(
         &fn,
     const mx::array &cond, float temperature, int top_k, float cfg_musiccoca,
     float cfg_notes, float cfg_drums, const std::vector<mx::array> &neg_arrays,
-    const std::vector<mx::array> &state, int dynamic_rvq_depth) {
+    const std::vector<mx::array> &state, int dynamic_rvq_depth,
+    int num_cfgs) {
   std::vector<mx::array> args;
   args.push_back(cond);
   args.push_back(mx::array({temperature}));
@@ -191,7 +193,10 @@ static std::pair<mx::array, std::vector<mx::array>> run_step(
   args.push_back(mx::array({cfg_musiccoca}));
   args.push_back(mx::array({cfg_notes}));
   args.push_back(mx::array({cfg_drums}));
-  args.insert(args.end(), neg_arrays.begin(), neg_arrays.end());
+  // Only include negative conditioning arrays when CFGs are enabled.
+  for (int i = 0; i < num_cfgs && i < static_cast<int>(neg_arrays.size()); ++i) {
+    args.push_back(neg_arrays[i]);
+  }
   args.push_back(
       mx::zeros({1, 0, dynamic_rvq_depth}, mx::int32)); // forced_tokens
   args.insert(args.end(), state.begin(), state.end());
@@ -205,9 +210,10 @@ static std::pair<mx::array, std::vector<mx::array>> run_step(
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 int main(int argc, char *argv[]) {
-  // Parse arguments: benchmark_mlxfn [model_dir] [num_steps]
+  // Parse arguments: benchmark_mlxfn [model_dir] [num_steps] [num_cfgs]
   std::string model_dir = "resources";
   int num_steps = kDefaultNumSteps;
+  int num_cfgs = 2; // default: musiccoca + notes
 
   // Scan for positional args
   std::vector<std::string> positional;
@@ -219,6 +225,8 @@ int main(int argc, char *argv[]) {
     model_dir = positional[0];
   if (positional.size() >= 2)
     num_steps = std::atoi(positional[1].c_str());
+  if (positional.size() >= 3)
+    num_cfgs = std::atoi(positional[2].c_str());
 
   // Strip trailing slashes
   while (!model_dir.empty() && model_dir.back() == '/')
@@ -239,6 +247,7 @@ int main(int argc, char *argv[]) {
   printf("  Model:       %s\n", mlxfn_path.c_str());
   printf("  State:       %s\n", state_path.c_str());
   printf("  Num steps:   %d\n", num_steps);
+  printf("  Num CFGs:    %d\n", num_cfgs);
   printf("───────────────────────────────────────────────────────────────\n\n");
 
   // ── Load model ──────────────────────────────────────────────────────
@@ -268,7 +277,9 @@ int main(int argc, char *argv[]) {
       dynamic_rvq_depth = shape[2];
     }
   }
-  printf("       ✓ Deduced dynamic RVQ depth: %d\n\n", dynamic_rvq_depth);
+  printf("       ✓ Deduced dynamic RVQ depth: %d\n", dynamic_rvq_depth);
+
+  printf("       ✓ Using num_cfgs: %d\n\n", num_cfgs);
 
   // ── Build conditioning input ────────────────────────────────────────
   auto cond = make_cond_input();
@@ -280,7 +291,7 @@ int main(int argc, char *argv[]) {
     auto [diag_audio, diag_state] =
         run_step(compiled_fn, cond, kDefaultTemperature, kDefaultTopK,
                  kDefaultCfgMusicCoCa, kDefaultCfgNotes, kDefaultCfgDrums,
-                 neg_arrays, initial_state, dynamic_rvq_depth);
+                 neg_arrays, initial_state, dynamic_rvq_depth, num_cfgs);
     mx::eval(diag_audio);
 
     // Print shape and dtype
@@ -326,7 +337,7 @@ int main(int argc, char *argv[]) {
     auto [audio, new_state] =
         run_step(compiled_fn, cond, kDefaultTemperature, kDefaultTopK,
                  kDefaultCfgMusicCoCa, kDefaultCfgNotes, kDefaultCfgDrums,
-                 neg_arrays, state, dynamic_rvq_depth);
+                 neg_arrays, state, dynamic_rvq_depth, num_cfgs);
     mx::eval(audio);
     mx::eval(new_state);
     state = std::move(new_state);
@@ -353,7 +364,7 @@ int main(int argc, char *argv[]) {
     auto [audio, new_state] =
         run_step(compiled_fn, cond, kDefaultTemperature, kDefaultTopK,
                  kDefaultCfgMusicCoCa, kDefaultCfgNotes, kDefaultCfgDrums,
-                 neg_arrays, state, dynamic_rvq_depth);
+                 neg_arrays, state, dynamic_rvq_depth, num_cfgs);
     mx::eval(audio);
     mx::eval(new_state);
 

--- a/magenta_rt/__init__.py
+++ b/magenta_rt/__init__.py
@@ -20,7 +20,7 @@ _vendor_hook.install()
 del _vendor_hook
 
 __version__ = "2.0.2"
-__all__ = ["MagentaRT2Jax", "MagentaRT2Mlx", "MagentaRT2Mlxfn"]
+__all__ = ["MagentaRT2Jax", "MagentaRT2Mlx", "MagentaRT2StdMlxfn"]
 
 
 def __getattr__(name):
@@ -42,13 +42,13 @@ def __getattr__(name):
           "Install them with: pip install magenta-rt[mlx]"
       ) from e
     return MagentaRT2System
-  if name == "MagentaRT2Mlxfn":
+  if name == "MagentaRT2StdMlxfn":
     try:
-      from magenta_rt.mlx.system import MagentaRT2SystemMlxfn
+      from magenta_rt.mlx.system import MagentaRT2SystemStdMlxfn
     except ImportError as e:
       raise ImportError(
-          "MagentaRTV2SystemMlxfn requires MLX dependencies. "
+          "MagentaRTV2SystemStdMlxfn requires MLX dependencies. "
           "Install them with: pip install magenta-rt[mlx]"
       ) from e
-    return MagentaRT2SystemMlxfn
+    return MagentaRT2SystemStdMlxfn
   raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/magenta_rt/config.py
+++ b/magenta_rt/config.py
@@ -214,21 +214,3 @@ MUSICCOCA = TokensConfig(
     frame_rate=SPECTROSTREAM.frame_rate,
     embedding_size=768,
 )
-
-INPUT_SPECTROSTREAM: TokensConfig = TokensConfig(
-    key='input_soundstream_tokens',
-    codebook_size=1024,
-    rvq_levels=64,
-    rvq_truncation_level=8,
-    frame_rate=25,
-    dropout_prob=TOKEN_DROPOUT_PROB,
-)
-
-MOSIC = TokensConfig(
-    key='mosic_tokens',
-    codebook_size=5,
-    rvq_levels=1,
-    rvq_truncation_level=1,
-    frame_rate=25,
-    dropout_prob=TOKEN_DROPOUT_PROB,
-)

--- a/magenta_rt/config.py
+++ b/magenta_rt/config.py
@@ -108,6 +108,7 @@ class TokensConfig:
 
   key: str = 'embeddings'
   codebook_size: int = -1
+  step: float | None = None # step used in the CFG discretization
   rvq_levels: int = -1
   rvq_truncation_level: int = -1
   quantizer: str | None = None
@@ -176,10 +177,10 @@ DRUM_PIANOROLL = TokensConfig(
 )
 
 # CFG scales. Values in range [-1.0, 7.0].
-# Discretized using step = 8.0 / (codebook_size - 1).
 CFG_CONDITIONING_MUSICCOCA_NOTES = TokensConfig(
     key='cfg_conditioning_tokens',
     codebook_size=41,
+    step=0.2,  # step used in the CFG discretization: CFG = -1.0 + step * CFG_codes
     rvq_levels=2,
     rvq_truncation_level=2,
     frame_rate=25,
@@ -187,9 +188,11 @@ CFG_CONDITIONING_MUSICCOCA_NOTES = TokensConfig(
     cfg_scale_keys=['musiccoca', 'notes']
 )
 
+# CFG scales. Values in range [-1.0, 7.0].
 CFG_CONDITIONING_DRUMS = TokensConfig(
     key='cfg_conditioning_drums_tokens',
     codebook_size=9,
+    step=1.0,  # step used in the CFG discretization: CFG = -1.0 + step * CFG_codes
     rvq_levels=1,
     rvq_truncation_level=1,
     frame_rate=25,

--- a/magenta_rt/config.py
+++ b/magenta_rt/config.py
@@ -115,6 +115,7 @@ class TokensConfig:
   frame_rate: float = -1
   dropout_prob: float | None = None
   embedding_size: int = -1
+  cfg_scale_keys: list[str] | None = None # If the token represents a CFG value
 
   @property
   def dimension(self) -> int:
@@ -145,6 +146,13 @@ class TokensConfig:
 
 TOKEN_DROPOUT_PROB = 0.15
 
+# Notes conditioning (128 ints). Each slot represents the state of
+# the corresponding pitch (0-127). The state can be:
+#   -1: means the pitch is masked out.
+#    0: means the pitch is off.
+#    1: means the pitch is on, but it's not the first time.
+#    2: means the pitch is on for the first time (i.e., onset).
+#    3: means the pitch is on (model has freedom to play it as onset or continuation).
 PIANOROLL_WITH_ONSETS = TokensConfig(
     key='pianoroll_with_onsets_tokens',
     codebook_size=4,
@@ -154,6 +162,10 @@ PIANOROLL_WITH_ONSETS = TokensConfig(
     dropout_prob=TOKEN_DROPOUT_PROB,
 )
 
+# Drums conditioning (1 int).
+#   -1: means masked
+#    0: no drum
+#    1: play drum
 DRUM_PIANOROLL = TokensConfig(
     key='drum_pianoroll_tokens',
     codebook_size=2,
@@ -163,6 +175,8 @@ DRUM_PIANOROLL = TokensConfig(
     dropout_prob=TOKEN_DROPOUT_PROB,
 )
 
+# CFG scales. Values in range [-1.0, 7.0].
+# Discretized using step = 8.0 / (codebook_size - 1).
 CFG_CONDITIONING_MUSICCOCA_NOTES = TokensConfig(
     key='cfg_conditioning_tokens',
     codebook_size=41,
@@ -170,6 +184,7 @@ CFG_CONDITIONING_MUSICCOCA_NOTES = TokensConfig(
     rvq_truncation_level=2,
     frame_rate=25,
     dropout_prob=None,
+    cfg_scale_keys=['musiccoca', 'notes']
 )
 
 CFG_CONDITIONING_DRUMS = TokensConfig(
@@ -179,6 +194,7 @@ CFG_CONDITIONING_DRUMS = TokensConfig(
     rvq_truncation_level=1,
     frame_rate=25,
     dropout_prob=None,
+    cfg_scale_keys=['drums']
 )
 
 SPECTROSTREAM = TokensConfig(
@@ -197,4 +213,22 @@ MUSICCOCA = TokensConfig(
     rvq_truncation_level=12,
     frame_rate=SPECTROSTREAM.frame_rate,
     embedding_size=768,
+)
+
+INPUT_SPECTROSTREAM: TokensConfig = TokensConfig(
+    key='input_soundstream_tokens',
+    codebook_size=1024,
+    rvq_levels=64,
+    rvq_truncation_level=8,
+    frame_rate=25,
+    dropout_prob=TOKEN_DROPOUT_PROB,
+)
+
+MOSIC = TokensConfig(
+    key='mosic_tokens',
+    codebook_size=5,
+    rvq_levels=1,
+    rvq_truncation_level=1,
+    frame_rate=25,
+    dropout_prob=TOKEN_DROPOUT_PROB,
 )

--- a/magenta_rt/jax/generate.py
+++ b/magenta_rt/jax/generate.py
@@ -36,6 +36,12 @@ def main(
     checkpoint: str | None = None,
     duration: float = 4.0,
 ):
+    cfg_scales = {
+        'musiccoca': cfg_musiccoca,
+        'notes': cfg_notes,
+        'drums': 1.0,
+    }
+
     mrt = MagentaRT2Jax(
         size=model_name,
         checkpoint=checkpoint,

--- a/magenta_rt/jax/generate.py
+++ b/magenta_rt/jax/generate.py
@@ -19,6 +19,7 @@ import time
 
 from magenta_rt import paths
 from magenta_rt import MagentaRT2Jax
+from magenta_rt.config import MUSICCOCA
 
 logging.basicConfig(level=logging.INFO, force=True)
 
@@ -40,8 +41,7 @@ def main(
         checkpoint=checkpoint,
         temperature=temperature,
         top_k=top_k,
-        cfg_musiccoca=cfg_musiccoca,
-        cfg_notes=cfg_notes,
+        cfg_scales=cfg_scales,
     )
 
     embedding = mrt.embed_style(prompt, use_mapper=True)
@@ -50,7 +50,7 @@ def main(
 
     # --- Benchmark ---
     start_time = time.time()
-    wav, state = mrt.generate(style=embedding, frames=frames)
+    wav, state = mrt.generate(conditioning={MUSICCOCA.key: embedding}, frames=frames)
     elapsed = time.time() - start_time
     ms_per_step = (elapsed / frames) * 1000
     print(f"Generated {frames} frames in {elapsed:.1f}s "

--- a/magenta_rt/jax/model.py
+++ b/magenta_rt/jax/model.py
@@ -239,7 +239,7 @@ class MagentaRT2ModelBase(metaclass=abc.ABCMeta):
 
     if self.use_pretrained_musiccoca_embedder:
       musiccoca_cfg = self.input_configs[0]
-      assert musiccoca_cfg.key == 'mulan_tokens_25hz', (
+      assert musiccoca_cfg.key == MUSICCOCA.key, (
           f'Expected first input config to be MusicCoCa, got {musiccoca_cfg.key}'
       )
 

--- a/magenta_rt/jax/system.py
+++ b/magenta_rt/jax/system.py
@@ -32,6 +32,7 @@ from . import spectrostream
 from .. import audio
 from .. import musiccoca
 from .. import paths
+from ..config import MUSICCOCA
 
 
 logger = logging.getLogger(__name__)
@@ -191,9 +192,7 @@ class MagentaRT2System:
       checkpoint: str | None = None,
       temperature: float = 1.3,
       top_k: int = 40,
-      cfg_musiccoca: float = 3.0,
-      cfg_notes: float = 1.0,
-      cfg_drums: float = 1.0,
+      cfg_scales: dict[str, float] | None = None,
   ):
     """Initialise the system: build model, load weights, JIT-compile.
 
@@ -204,9 +203,11 @@ class MagentaRT2System:
       checkpoint: Override checkpoint filename. If None, looked up from size.
       temperature: Sampling temperature.
       top_k: Top-k sampling threshold.
-      cfg_musiccoca: Classifier-free guidance scale for MusicCoCa.
-      cfg_notes: Classifier-free guidance scale for notes.
-      cfg_drums: Classifier-free guidance scale for drums.
+      cfg_scales: Classifier-free guidance scale for the different inputs.
+          Standard models need musiccoca, notes, and drums, while A2A models
+          need musiccoca, audio, and mosic.
+          Note: The CFG scales don't expand the inference batch but are used
+          as additional conditioning tokens.
     """
     self._model = model_configs.get_model_class(size)()
     self._size = size
@@ -238,25 +239,24 @@ class MagentaRT2System:
     logger.info('Loading checkpoint: %s', checkpoint_path)
     self._params = _load_jax_weights(checkpoint_path)
 
+    # --- Log parameter count ---
+    num_params = sum(
+        v.size for v in jax.tree.leaves(self._params)
+    )
+    logger.info('Total parameters: %s', f'{num_params:,}')
+
     # --- Sampling defaults ---
     self.temperature = temperature
     self.top_k = top_k
-    self.cfg_musiccoca = cfg_musiccoca
-    self.cfg_notes = cfg_notes
-    self.cfg_drums = cfg_drums
+    self.cfg_scales = cfg_scales or {
+        'musiccoca': 3.0,
+        'notes': 1.0,
+        'drums': 1.0,
+    }
 
     # --- Derived constants ---
-    self._num_musiccoca_tokens = self._model.input_configs[0].rvq_truncation_level
-    self._num_notes = self._model.input_configs[1].rvq_truncation_level
-    self._drum_tokens = self._model.input_configs[2].rvq_truncation_level
-    self._cfg_tokens = sum(
-        cfg.rvq_truncation_level for cfg in self._model.input_configs[3:]
-    )
-    self._num_channels = (
-        self._num_musiccoca_tokens
-        + self._num_notes
-        + self._drum_tokens
-        + self._cfg_tokens
+    self._num_channels = sum(
+      x.rvq_truncation_level for x in self._model.input_configs
     )
 
     # --- AOT-compiled functions ---
@@ -302,11 +302,11 @@ class MagentaRT2System:
     t0 = time.time()
 
     # Create dummy conditioning to get concrete shapes.
-    dummy_style = [1] * self._num_musiccoca_tokens
-    dummy_notes = [-1] * self._num_notes
-    dummy_drums = [-1] * self._drum_tokens
-    dummy_cfg = [-1] * self._cfg_tokens
-    block, constants = self._build_conditioning(dummy_style, dummy_notes, dummy_drums, dummy_cfg)
+    conditioning = {}
+    for cfg in self._model.input_configs:
+      conditioning[cfg.key] = [-1] * cfg.rvq_truncation_level
+
+    block, constants = self._build_conditioning(conditioning)
 
     init_constants = {}
     state = self._jit_init_state(self._params, init_constants)
@@ -337,10 +337,8 @@ class MagentaRT2System:
 
   def _build_conditioning(
       self,
-      style: musiccoca.StyleTokens | list[int],
-      notes: list[int] | None = None,
-      drums: list[int] | None = None,
-      cfgs: list[int] | None = None,
+      conditioning: dict[str, list[int] | np.ndarray],
+      cfg_scales: dict[str, float] | None = None,
       temperature: float | None = None,
       top_k: int | None = None,
   ) -> tuple[sl.Sequence, dict]:
@@ -351,37 +349,47 @@ class MagentaRT2System:
       and constants contains temperature, top_k, CFG scales, and negative
       conditioning sequences.
     """
+    cond_list = []
 
-    style_tokens = list(style) if not isinstance(style, list) else style
-    notes_tokens = notes if notes is not None else [-1] * self._num_notes
-    drums_tokens = drums if drums is not None else [-1] * self._drum_tokens
-    # default cfgs_tokens [20, 20, 4] => cfg values [3.0, 3.0, 3.0]
-    if cfgs is None:
-      cfgs_tokens = [
-          int((self.cfg_musiccoca + 1.0) / 0.2),
-          int((self.cfg_notes + 1.0) / 0.2),
-          4,
-      ]
-    else:
-      cfgs_tokens = cfgs
+    # Merge class defaults with passed overrides
+    scales = self.cfg_scales.copy() if self.cfg_scales else {}
+    if cfg_scales:
+      scales.update(cfg_scales)
 
-    assert len(style_tokens) == self._num_musiccoca_tokens, (
-        f'Expected {self._num_musiccoca_tokens} style tokens, got {len(style_tokens)}'
-    )
-    assert len(notes_tokens) == self._num_notes, (
-        f'Expected {self._num_notes} notes, got {len(notes_tokens)}'
-    )
-    assert len(drums_tokens) == self._drum_tokens, (
-        f'Expected {self._drum_tokens} drums, got {len(drums_tokens)}'
-    )
-    assert len(cfgs_tokens) == self._cfg_tokens, (
-        f'Expected {self._cfg_tokens} CFG tokens, got {len(cfgs_tokens)}'
-    )
+    # ---
+    for cfg in self._model.input_configs:
+      # If the tokens were passed as conditioning
+      if cfg.key in conditioning:
+        tokens = list(conditioning[cfg.key])
+
+      # If it's CFG
+      elif cfg.cfg_scale_keys:
+        step = 8.0 / (cfg.codebook_size - 1)
+        tokens = []
+        for scale_key in cfg.cfg_scale_keys:
+          token = discretize_cfg(
+            scales.get(scale_key, 3.0),
+            step,
+            cfg.codebook_size - 1
+          )
+          tokens.append(token)
+        
+        tokens = tokens[:cfg.rvq_truncation_level]
+      
+      # Otherwise, use default unconditioned tokens
+      else:
+        tokens = [-1] * cfg.rvq_truncation_level
+
+      assert len(tokens) == cfg.rvq_truncation_level, (
+          f'Expected {cfg.rvq_truncation_level} tokens for {cfg.key},'
+          f' got {len(tokens)}'
+      )
+      cond_list.extend(tokens)
 
     offset = NUM_RESERVED_TOKENS + 1  # +1 for dropout token
 
     # Positive conditioning.
-    cond = np.array(style_tokens + notes_tokens + drums_tokens + cfgs_tokens, dtype=np.int32) + offset
+    cond = np.array(cond_list, dtype=np.int32) + offset
     block = sl.Sequence.from_values(cond.reshape(1, 1, -1))
 
     temperature = self.temperature if temperature is None else temperature
@@ -394,12 +402,8 @@ class MagentaRT2System:
 
   def generate(
       self,
-      style: musiccoca.StyleEmbedding | None = None,
-      notes: list[int] | None = None,
-      drums: list[int] | None = None,
-      cfg_musiccoca: float | None = None,
-      cfg_notes: float | None = None,
-      cfg_drums: float | None = None,
+      conditioning: dict[str, list[int] | np.ndarray] | None = None,
+      cfg_scales: dict[str, float] | None = None,
       temperature: float | None = None,
       top_k: int | None = None,
       frames: int = 25,
@@ -408,30 +412,10 @@ class MagentaRT2System:
     """Generate audio from style conditioning.
 
     Args:
-      style: Style embedding (768-dim ndarray from embed_style). None means
-          unconditional/masked.
-      notes: Notes conditioning (128 ints). Each slot represents the state of
-          the corresponding pitch (0-127). The state can be:
-          -1: means the pitch is masked out.
-           0: means the pitch is off.
-           1: means the pitch is on, but it's not the first time.
-           2: means the pitch is on for the first time (i.e., onset)
-           3: means the pitch is on (model has the freedom to play it as an
-              onset or continuation).
-        None means masked/silent (all pitches masked out).
-      drums: Drums conditioning (1 int).
-        -1: means masked
-         0: no drum
-         1: play drum
-      cfg_musiccoca: MusicCoCa classifier-free-guidance scale, a float in
-        [-1.0, 7.0]. None falls back to ``self.cfg_musiccoca``. Discretized to
-        a conditioning token with a 0.2 step (token 0 -> -1.0, token 1 -> -0.8,
-        ..., token 40 -> 7.0).
-      cfg_notes: Notes CFG scale, a float in [-1.0, 7.0]. None falls back to
-        ``self.cfg_notes``. Discretized with a 0.2 step like cfg_musiccoca.
-      cfg_drums: Drums CFG scale, a float in [-1.0, 7.0]. None falls back to
-        ``self.cfg_drums``. Discretized with a 1.0 step (token 0 -> -1.0,
-        token 1 -> 0.0, ..., token 8 -> 7.0).
+      conditioning: Dictionary mapping TokensConfig.key strings to their values
+        Values can be lists of integers (tokens) or raw embeddings (e.g. Style)
+      cfg_scales: Optional dictionary to override default CFG scales for this call.
+          Example: {'musiccoca': 5.0, 'notes': 3.0}
       temperature: Sampling temperature. None falls back to
         ``self.temperature``.
       top_k: Top-k sampling threshold. None falls back to ``self.top_k``.
@@ -443,30 +427,40 @@ class MagentaRT2System:
       (waveform, state) — a Waveform at 48kHz stereo, and the updated state
       for continuation.
     """
-    # --- Resolve style to tokens ---
-    if style is None:
-      style_tokens = [-1] * self._num_musiccoca_tokens
-    else:
-      style_tokens = self._style_model.tokenize(style).tolist()
+    conditioning = conditioning or {}
+    tokenized_conditioning = {}
+    
+    for key, value in conditioning.items():
+      if value is None:
+        continue
 
-    # Pad or truncate to expected length.
-    if len(style_tokens) < self._num_musiccoca_tokens:
-      style_tokens = style_tokens + [-1] * (self._num_musiccoca_tokens - len(style_tokens))
-    style_tokens = style_tokens[:self._num_musiccoca_tokens]
+      # If it's already an array or list of tokens (not float embedding), no need to tokenize
+      if isinstance(value, np.ndarray) and value.dtype in (np.float32, np.float64, np.float16):
+        pass # Float embedding, needs tokenization
+      elif isinstance(value, (list, np.ndarray)):
+        tokenized_conditioning[key] = list(value)
+        continue
 
-    # --- Resolve CFG scales and discretize to conditioning tokens ---
-    cfg_musiccoca = self.cfg_musiccoca if cfg_musiccoca is None else cfg_musiccoca
-    cfg_notes = self.cfg_notes if cfg_notes is None else cfg_notes
-    cfg_drums = self.cfg_drums if cfg_drums is None else cfg_drums
-    cfgs = [
-        discretize_cfg(cfg_musiccoca, 0.2, 40),
-        discretize_cfg(cfg_notes, 0.2, 40),
-        discretize_cfg(cfg_drums, 1.0, 8),
-    ]
+      # Otherwise, get truncation level and tokenize
+      cfg = next((c for c in self._model.input_configs if c.key == key), None)
+      if cfg is None:
+        raise ValueError(f'No config found for key {key}')
+
+      if key == MUSICCOCA.key:
+        tokens = self._style_model.tokenize(value).tolist()
+      else:
+        raise ValueError(
+          f"Automatic tokenization for '{key}' is not implemented."
+        )
+
+      # Pad or truncate to expected length.
+      if len(tokens) < cfg.rvq_truncation_level:
+        tokens = tokens + [-1] * (cfg.rvq_truncation_level - len(tokens))
+      tokenized_conditioning[key] = tokens[:cfg.rvq_truncation_level]
 
     # --- Build conditioning ---
     block, constants = self._build_conditioning(
-        style_tokens, notes, drums, cfgs, temperature, top_k
+        tokenized_conditioning, cfg_scales, temperature, top_k
     )
 
     # --- Init state if needed ---

--- a/magenta_rt/jax/system.py
+++ b/magenta_rt/jax/system.py
@@ -204,8 +204,7 @@ class MagentaRT2System:
       temperature: Sampling temperature.
       top_k: Top-k sampling threshold.
       cfg_scales: Classifier-free guidance scale for the different inputs.
-          Standard models need musiccoca, notes, and drums, while A2A models
-          need musiccoca, audio, and mosic.
+          Standard models need musiccoca, notes, and drums.
           Note: The CFG scales don't expand the inference batch but are used
           as additional conditioning tokens.
     """

--- a/magenta_rt/jax/system.py
+++ b/magenta_rt/jax/system.py
@@ -363,12 +363,11 @@ class MagentaRT2System:
 
       # If it's CFG
       elif cfg.cfg_scale_keys:
-        step = 8.0 / (cfg.codebook_size - 1)
         tokens = []
         for scale_key in cfg.cfg_scale_keys:
           token = discretize_cfg(
             scales.get(scale_key, 3.0),
-            step,
+            cfg.step,
             cfg.codebook_size - 1
           )
           tokens.append(token)

--- a/magenta_rt/mlx/export.py
+++ b/magenta_rt/mlx/export.py
@@ -28,9 +28,7 @@ from .load_weights import load_weights, convert_to_bf16
 from magenta_rt import paths
 from magenta_rt.config import (
     DRUM_PIANOROLL,
-    INPUT_SPECTROSTREAM,
     MUSICCOCA,
-    MOSIC,
     PIANOROLL_WITH_ONSETS
 )
 
@@ -321,8 +319,6 @@ def main(
                             tokens = [-1] * cfg.rvq_truncation_level
                         elif cfg.key == PIANOROLL_WITH_ONSETS.key and mask_key == 'notes':
                             tokens = [-1] * cfg.rvq_truncation_level
-                        elif cfg.key == INPUT_SPECTROSTREAM.key and mask_key == 'audio':
-                            tokens = [-1] * cfg.rvq_truncation_level
                         # Otherwise use positive tokens
                         elif cfg.key == MUSICCOCA.key:
                             tokens = list(musiccoca_tokens)
@@ -421,8 +417,6 @@ def main(
                 tokens = [-1] * cfg.rvq_truncation_level
             elif cfg.key == PIANOROLL_WITH_ONSETS.key and mask_key == 'notes':
                 tokens = [-1] * cfg.rvq_truncation_level
-            elif cfg.key == INPUT_SPECTROSTREAM.key and mask_key == 'audio':
-                tokens = [-1] * cfg.rvq_truncation_level
             # Otherwise use positive tokens
             elif cfg.key == MUSICCOCA.key:
                 tokens = list(musiccoca)
@@ -442,19 +436,13 @@ def main(
     cfg_musiccoca_val = mx.array([cfg_musiccoca])
     cfg_notes_val = mx.array([cfg_notes])
     cfg_drums_val = mx.array([cfg_drums])
-    cfg_audio_val = mx.array([cfg_audio])
-    cfg_mosic_val = mx.array([cfg_mosic])
 
     constants = {
         "temperature": t_val,
         "top_k": k_val,
     }
     for key in cfg_keys:
-        scale_val = (
-            cfg_musiccoca_val if key == 'musiccoca' else
-            cfg_notes_val if key == 'notes' else
-            cfg_audio_val
-        )
+        scale_val = cfg_musiccoca_val if key == 'musiccoca' else cfg_notes_val
         constants[f"classifier_free_guidance_scale_{key}"] = scale_val
         constants[f"classifier_free_guidance_negative_{key}"] = negatives[key]
 
@@ -523,10 +511,6 @@ def main(
                 warmup_args.append(cfg_notes_val)
             elif cfg.key == DRUM_PIANOROLL.key:
                 warmup_args.append(cfg_drums_val)
-            elif cfg.key == INPUT_SPECTROSTREAM.key:
-                warmup_args.append(cfg_audio_val)
-            elif cfg.key == MOSIC.key:
-                warmup_args.append(cfg_mosic_val)
         for key in cfg_keys:
             warmup_args.append(negatives[key].values)
         warmup_args.append(empty_forced_tokens)
@@ -556,10 +540,6 @@ def main(
                 args.append(cfg_notes_val)
             elif cfg.key == DRUM_PIANOROLL.key:
                 args.append(cfg_drums_val)
-            elif cfg.key == INPUT_SPECTROSTREAM.key:
-                args.append(cfg_audio_val)
-            elif cfg.key == MOSIC.key:
-                args.append(cfg_mosic_val)
         for key in cfg_keys:
             args.append(negatives[key].values)
         args.append(empty_forced_tokens)
@@ -578,10 +558,6 @@ def main(
                 args2.append(cfg_notes_val)
             elif cfg.key == DRUM_PIANOROLL.key:
                 args2.append(cfg_drums_val)
-            elif cfg.key == INPUT_SPECTROSTREAM.key:
-                args2.append(cfg_audio_val)
-            elif cfg.key == MOSIC.key:
-                args2.append(cfg_mosic_val)
         for key in cfg_keys:
             args2.append(negatives[key].values)
         args2.append(forced_tokens)

--- a/magenta_rt/mlx/export.py
+++ b/magenta_rt/mlx/export.py
@@ -387,9 +387,9 @@ def main(
     musiccoca = [660, 1016, 295, 206, 857, 841, 391, 857, 619, 70, 401, 22]
     musiccoca = musiccoca[:num_musiccoca_tokens]
 
-    cfg_keys = ['musiccoca', 'notes']
+    standard_cfg_keys = ['musiccoca', 'notes']
 
-    cfg_keys = cfg_keys[:num_cfgs]
+    cfg_keys = standard_cfg_keys[:num_cfgs]
 
     # Build positive conditioning sequence
     cond_list = []
@@ -429,7 +429,7 @@ def main(
             mx.array([[True]], dtype=mx.bool_),
         )
 
-    negatives = {key: make_negative(key) for key in cfg_keys}
+    negatives = {key: make_negative(key) for key in standard_cfg_keys}
 
     t_val = mx.array([temperature])
     k_val = mx.array([top_k], dtype=mx.int32)
@@ -464,7 +464,7 @@ def main(
         # behavior where each negative was a copy of the positive conditioning
         # with one modality masked.
         num_scales = sum(1 for cfg in exp.input_configs if 'cfg' not in cfg.key)
-        num_negs = len(cfg_keys)
+        num_negs = len(standard_cfg_keys)
 
         scales_args = list(flat_args[:num_scales])
         negs_args = list(flat_args[num_scales:num_scales + num_negs])
@@ -511,7 +511,7 @@ def main(
                 warmup_args.append(cfg_notes_val)
             elif cfg.key == DRUM_PIANOROLL.key:
                 warmup_args.append(cfg_drums_val)
-        for key in cfg_keys:
+        for key in standard_cfg_keys:
             warmup_args.append(negatives[key].values)
         warmup_args.append(empty_forced_tokens)
         warmup_args.extend(flat_state)
@@ -540,7 +540,7 @@ def main(
                 args.append(cfg_notes_val)
             elif cfg.key == DRUM_PIANOROLL.key:
                 args.append(cfg_drums_val)
-        for key in cfg_keys:
+        for key in standard_cfg_keys:
             args.append(negatives[key].values)
         args.append(empty_forced_tokens)
         args.extend(flat_state)
@@ -558,7 +558,7 @@ def main(
                 args2.append(cfg_notes_val)
             elif cfg.key == DRUM_PIANOROLL.key:
                 args2.append(cfg_drums_val)
-        for key in cfg_keys:
+        for key in standard_cfg_keys:
             args2.append(negatives[key].values)
         args2.append(forced_tokens)
         args2.extend(flat_state)

--- a/magenta_rt/mlx/export.py
+++ b/magenta_rt/mlx/export.py
@@ -26,6 +26,13 @@ from . import model, system
 from . import spectrostream
 from .load_weights import load_weights, convert_to_bf16
 from magenta_rt import paths
+from magenta_rt.config import (
+    DRUM_PIANOROLL,
+    INPUT_SPECTROSTREAM,
+    MUSICCOCA,
+    MOSIC,
+    PIANOROLL_WITH_ONSETS
+)
 
 
 def _flatten_state(state):
@@ -166,9 +173,7 @@ def main(
     exp_cls = model.get_model_class(model_name)
     exp = exp_cls()
     musiccoca_tokens_cfg = exp.input_configs[0]
-    pianoroll_tokens_cfg = exp.input_configs[1]
     num_musiccoca_tokens = musiccoca_tokens_cfg.rvq_truncation_level
-    num_pitches = pianoroll_tokens_cfg.rvq_truncation_level
     print(f"Using model: {model_name} ({exp_cls.__name__})")
 
     # Build depthformer_config kwargs — only override what was explicitly set,
@@ -285,41 +290,66 @@ def main(
             # (at 25Hz), cycling through all 128 prompts once. This gives
             # ~384 activation samples per layer (128 steps × 3 CFG batch).
 
-            _notes = [-1] * num_pitches
-            _masked_musiccoca = [-1] * num_musiccoca_tokens
-            _masked_notes = [-1] * num_pitches
             _t_val = mx.array([temperature])
             _k_val = mx.array([top_k], dtype=mx.int32)
             _cfg_musiccoca_val = mx.array([cfg_musiccoca])
             _cfg_notes_val = mx.array([cfg_notes])
 
+            cfg_keys = ['musiccoca', 'notes']
+
+            cfg_keys = cfg_keys[:num_cfgs]
+
             def _make_cal_inputs(musiccoca_tokens):
                 """Build conditioning inputs for a single MusicCoCa prompt."""
-                cond = np.concatenate([musiccoca_tokens, _notes], axis=0) + NUM_RESERVED_TOKENS
+                c_list = []
+                for cfg in exp.input_configs:
+                    if cfg.key == MUSICCOCA.key:
+                        tokens = list(musiccoca_tokens)
+                    else:
+                        tokens = [-1] * cfg.rvq_truncation_level
+                    c_list.extend(tokens)
+                cond = np.array(c_list, dtype=np.int32) + NUM_RESERVED_TOKENS
                 block = sl.Sequence(
                     mx.array(cond.reshape(1, 1, -1), dtype=mx.int32),
                     mx.array([[True]], dtype=mx.bool_),
                 )
-                neg_musiccoca = sl.Sequence(
-                    mx.array([[_masked_musiccoca + _notes]], dtype=mx.int32) + NUM_RESERVED_TOKENS,
-                    mx.array([[True]], dtype=mx.bool_),
-                )
-                neg_notes = sl.Sequence(
-                    mx.array([[musiccoca_tokens + _masked_notes]], dtype=mx.int32) + NUM_RESERVED_TOKENS,
-                    mx.array([[True]], dtype=mx.bool_),
-                )
+
+                def _make_cal_neg(mask_key):
+                    neg_list = []
+                    for cfg in exp.input_configs:
+                        if cfg.key == MUSICCOCA.key and mask_key == 'musiccoca':
+                            tokens = [-1] * cfg.rvq_truncation_level
+                        elif cfg.key == PIANOROLL_WITH_ONSETS.key and mask_key == 'notes':
+                            tokens = [-1] * cfg.rvq_truncation_level
+                        elif cfg.key == INPUT_SPECTROSTREAM.key and mask_key == 'audio':
+                            tokens = [-1] * cfg.rvq_truncation_level
+                        # Otherwise use positive tokens
+                        elif cfg.key == MUSICCOCA.key:
+                            tokens = list(musiccoca_tokens)
+                        else:
+                            tokens = [-1] * cfg.rvq_truncation_level
+                        neg_list.extend(tokens)
+                    neg_tokens = np.array(neg_list, dtype=np.int32) + NUM_RESERVED_TOKENS
+                    return sl.Sequence(
+                        mx.array(neg_tokens.reshape(1, 1, -1), dtype=mx.int32),
+                        mx.array([[True]], dtype=mx.bool_),
+                    )
+
                 constants = {
                     "temperature": _t_val,
                     "top_k": _k_val,
-                    "classifier_free_guidance_scale_musiccoca": _cfg_musiccoca_val,
-                    "classifier_free_guidance_scale_notes": _cfg_notes_val,
-                    "classifier_free_guidance_negative_musiccoca": neg_musiccoca,
-                    "classifier_free_guidance_negative_notes": neg_notes,
                 }
+                for key in cfg_keys:
+                    scale_val = (
+                        _cfg_musiccoca_val if key == 'musiccoca' else
+                        _cfg_notes_val
+                    )
+                    constants[f"classifier_free_guidance_scale_{key}"] = scale_val
+                    constants[f"classifier_free_guidance_negative_{key}"] = _make_cal_neg(key)
                 return block, constants
 
             def _calibrate_fn(model_unused):
-                _input_spec = sl.ChannelSpec(shape=(num_musiccoca_tokens + num_pitches,), dtype=mx.int32)
+                _input_spec = sl.ChannelSpec(shape=(exp.input_num_channels,), dtype=mx.int32)
                 # Run multiple streaming steps per prompt before switching.
                 # State is continuous (no reset) — captures both within-prompt
                 # temporal evolution and prompt transition dynamics.
@@ -329,10 +359,10 @@ def main(
                     1, _input_spec, constants=first_constants, training=False)
                 for step_i in range(gptq_cal_steps):
                     prompt_idx = (step_i // steps_per_prompt) % len(musiccoca_prompts)
-                    cal_block, cal_constants = _make_cal_inputs(musiccoca_prompts[prompt_idx])
+                    block, constants = _make_cal_inputs(musiccoca_prompts[prompt_idx])
                     y, _state, _ = mrt_sampler.step_with_emits(
-                        x=cal_block, state=_state,
-                        constants=cal_constants, training=False)
+                        x=block, state=_state,
+                        constants=constants, training=False)
                     mx.eval(y.values)
                     if (step_i + 1) % 32 == 0:
                         print(f"    Calibration step {step_i + 1}/{gptq_cal_steps}")
@@ -357,107 +387,124 @@ def main(
         return mrt_sampler.get_initial_state(1, input_spec, constants=constants, training=False)
 
     # --- Set up conditioning inputs ---
+    # Drums: -1:"let model decide"; 0:"don't play drums"; 1:"please play drums"
     musiccoca = [660, 1016, 295, 206, 857, 841, 391, 857, 619, 70, 401, 22]
     musiccoca = musiccoca[:num_musiccoca_tokens]
-    notes = [-1] * num_pitches
-    drums = [-1]  # -1->"let model decide"; 0->"don't play drums"; 1->"please play drums"
-    masked_musiccoca = [-1] * num_musiccoca_tokens
-    masked_notes = [-1] * num_pitches
-    cond_tokens = np.concatenate([musiccoca, notes, drums], axis=0) + NUM_RESERVED_TOKENS
+
+    cfg_keys = ['musiccoca', 'notes']
+
+    cfg_keys = cfg_keys[:num_cfgs]
+
+    # Build positive conditioning sequence
+    cond_list = []
+    for cfg in exp.input_configs:
+        if 'cfg' in cfg.key:
+            continue
+        if cfg.key == MUSICCOCA.key:
+            tokens = list(musiccoca)
+        else:
+            tokens = [-1] * cfg.rvq_truncation_level
+        cond_list.extend(tokens)
+    cond_tokens = np.array(cond_list, dtype=np.int32) + NUM_RESERVED_TOKENS
     block = sl.Sequence(
         mx.array(cond_tokens.reshape(1, 1, -1), dtype=mx.int32),
         mx.array([[True]], dtype=mx.bool_),
     )
-    neg_musiccoca = sl.Sequence(
-        mx.array([[masked_musiccoca + notes + drums]], dtype=mx.int32) + NUM_RESERVED_TOKENS,
-        mx.array([[True]], dtype=mx.bool_),
-    )
-    neg_notes = sl.Sequence(
-        mx.array([[musiccoca + masked_notes + drums]], dtype=mx.int32) + NUM_RESERVED_TOKENS,
-        mx.array([[True]], dtype=mx.bool_),
-    )
+
+    # Build negative sequences
+    def make_negative(mask_key):
+        neg_list = []
+        for cfg in exp.input_configs:
+            if 'cfg' in cfg.key:
+                continue
+            if cfg.key == MUSICCOCA.key and mask_key == 'musiccoca':
+                tokens = [-1] * cfg.rvq_truncation_level
+            elif cfg.key == PIANOROLL_WITH_ONSETS.key and mask_key == 'notes':
+                tokens = [-1] * cfg.rvq_truncation_level
+            elif cfg.key == INPUT_SPECTROSTREAM.key and mask_key == 'audio':
+                tokens = [-1] * cfg.rvq_truncation_level
+            # Otherwise use positive tokens
+            elif cfg.key == MUSICCOCA.key:
+                tokens = list(musiccoca)
+            else:
+                tokens = [-1] * cfg.rvq_truncation_level
+            neg_list.extend(tokens)
+        neg_tokens = np.array(neg_list, dtype=np.int32) + NUM_RESERVED_TOKENS
+        return sl.Sequence(
+            mx.array(neg_tokens.reshape(1, 1, -1), dtype=mx.int32),
+            mx.array([[True]], dtype=mx.bool_),
+        )
+
+    negatives = {key: make_negative(key) for key in cfg_keys}
 
     t_val = mx.array([temperature])
     k_val = mx.array([top_k], dtype=mx.int32)
     cfg_musiccoca_val = mx.array([cfg_musiccoca])
     cfg_notes_val = mx.array([cfg_notes])
     cfg_drums_val = mx.array([cfg_drums])
+    cfg_audio_val = mx.array([cfg_audio])
+    cfg_mosic_val = mx.array([cfg_mosic])
 
-    if num_cfgs == 0:
-        # No CFG: batch = 1x (positive only, no guidance)
-        constants = {
-            "temperature": t_val,
-            "top_k": k_val,
-        }
-        print(f"Using 0 CFGs (disabled) → batch multiplier = 1x")
-    elif num_cfgs == 1:
-        # Only musiccoca CFG: batch = 2x (1 positive + 1 negative)
-        constants = {
-            "temperature": t_val,
-            "top_k": k_val,
-            "classifier_free_guidance_scale_musiccoca": cfg_musiccoca_val,
-            "classifier_free_guidance_negative_musiccoca": neg_musiccoca,
-        }
-        print(f"Using 1 CFG (musiccoca only) → batch multiplier = 2x")
-    else:
-        # All 2 CFGs: batch = 3x (1 positive + 2 negatives)
-        constants = {
-            "temperature": t_val,
-            "top_k": k_val,
-            "classifier_free_guidance_scale_musiccoca": cfg_musiccoca_val,
-            "classifier_free_guidance_scale_notes": cfg_notes_val,
-            "classifier_free_guidance_negative_musiccoca": neg_musiccoca,
-            "classifier_free_guidance_negative_notes": neg_notes,
-        }
-        print(f"Using 2 CFGs (musiccoca+notes) → batch multiplier = 3x")
+    constants = {
+        "temperature": t_val,
+        "top_k": k_val,
+    }
+    for key in cfg_keys:
+        scale_val = (
+            cfg_musiccoca_val if key == 'musiccoca' else
+            cfg_notes_val if key == 'notes' else
+            cfg_audio_val
+        )
+        constants[f"classifier_free_guidance_scale_{key}"] = scale_val
+        constants[f"classifier_free_guidance_negative_{key}"] = negatives[key]
 
+    print(f"Using {len(cfg_keys)} CFGs ({', '.join(cfg_keys)}) → batch multiplier = {len(cfg_keys)+1}x")
+
+    has_cfg_tokens = any('cfg' in cfg.key for cfg in exp.input_configs)
     state = init_state(constants)
     flat_state, structure = _flatten_state(state)
 
     # todo: this mx.compile decorator isn't helping performance for some reason.
     # @partial(mx.compile, inputs=(mx.random.state, structure), outputs=mx.random.state)
-    def streaming_step(x_values, temperature_arg, top_k_arg, cfg_musiccoca_arg, cfg_notes_arg, cfg_drums_arg, neg_musiccoca_values, neg_notes_values, forced_tokens, *state_flat):
+    def streaming_step(x_values, temperature_arg, top_k_arg, *flat_args):
         # Discretize the float CFG scales and append them to the conditioning
-        # token slots (musiccoca, notes, drums). This replaces the
+        # token slots (musiccoca, notes, drums) if required by the model. This replaces the
         # discretize_cfg() logic that previously lived in
         # core/src/mlx_engine.cpp: the C++ runtime now passes raw float scales
         # and the exported function bins them. The same tokens are written into
         # the positive block and both CFG negative blocks, matching the old C++
         # behavior where each negative was a copy of the positive conditioning
         # with one modality masked.
-        cfg_tokens = mx.concatenate([
-            _discretize_cfg_token(cfg_musiccoca_arg, 0.2, 40, NUM_RESERVED_TOKENS),
-            _discretize_cfg_token(cfg_notes_arg, 0.2, 40, NUM_RESERVED_TOKENS),
-            _discretize_cfg_token(cfg_drums_arg, 1.0, 8, NUM_RESERVED_TOKENS),
-        ], axis=-1).reshape(1, 1, 3)
-        x_values = mx.concatenate([x_values, cfg_tokens], axis=-1)
-        neg_musiccoca_values = mx.concatenate([neg_musiccoca_values, cfg_tokens], axis=-1)
-        neg_notes_values = mx.concatenate([neg_notes_values, cfg_tokens], axis=-1)
+        num_scales = sum(1 for cfg in exp.input_configs if 'cfg' not in cfg.key)
+        num_negs = len(cfg_keys)
+
+        scales_args = list(flat_args[:num_scales])
+        negs_args = list(flat_args[num_scales:num_scales + num_negs])
+        forced_tokens = flat_args[num_scales + num_negs]
+        state_flat = flat_args[num_scales + num_negs + 1:]
+
+        # todo: make number of CFG tokens configurable
+        if has_cfg_tokens:
+            cfg_tokens = mx.concatenate([
+                _discretize_cfg_token(scales_args[0], 0.2, 40, NUM_RESERVED_TOKENS),
+                _discretize_cfg_token(scales_args[1], 0.2, 40, NUM_RESERVED_TOKENS),
+                _discretize_cfg_token(scales_args[2], 1.0, 8, NUM_RESERVED_TOKENS),
+            ], axis=-1).reshape(1, 1, 3)
+            x_values = mx.concatenate([x_values, cfg_tokens], axis=-1)
+            negs_args = [
+                mx.concatenate([neg, cfg_tokens], axis=-1) for neg in negs_args
+            ]
 
         state = _unflatten_state(list(state_flat), structure)
         x = sl.Sequence(x_values, mx.array([[True]], dtype=mx.bool_))
 
-        if num_cfgs == 0:
-            dynamic_constants = {
-                "temperature": temperature_arg,
-                "top_k": top_k_arg,
-            }
-        elif num_cfgs == 1:
-            dynamic_constants = {
-                "temperature": temperature_arg,
-                "top_k": top_k_arg,
-                "classifier_free_guidance_scale_musiccoca": cfg_musiccoca_arg,
-                "classifier_free_guidance_negative_musiccoca": sl.Sequence(neg_musiccoca_values, mx.array([[True]], dtype=mx.bool_)),
-            }
-        else:
-            dynamic_constants = {
-                "temperature": temperature_arg,
-                "top_k": top_k_arg,
-                "classifier_free_guidance_scale_musiccoca": cfg_musiccoca_arg,
-                "classifier_free_guidance_scale_notes": cfg_notes_arg,
-                "classifier_free_guidance_negative_musiccoca": sl.Sequence(neg_musiccoca_values, mx.array([[True]], dtype=mx.bool_)),
-                "classifier_free_guidance_negative_notes": sl.Sequence(neg_notes_values, mx.array([[True]], dtype=mx.bool_)),
-            }
+        dynamic_constants = {
+            "temperature": temperature_arg,
+            "top_k": top_k_arg,
+        }
+        for i, key in enumerate(cfg_keys):
+            dynamic_constants[f"classifier_free_guidance_scale_{key}"] = scales_args[i]
+            dynamic_constants[f"classifier_free_guidance_negative_{key}"] = sl.Sequence(negs_args[i], mx.array([[True]], dtype=mx.bool_))
 
         y, new_state, _ = mrt_sampler.step_with_emits(x=x, state=state, constants=dynamic_constants, forced_tokens=forced_tokens, training=False)
         new_flat, _ = _flatten_state(new_state)
@@ -468,10 +515,24 @@ def main(
     empty_forced_tokens = mx.zeros((1, 0, rvq_truncation), dtype=mx.int32)
     print("warming up for export...")
     for _ in range(5):
-        y_values, *flat_state  = streaming_step(
-        block.values, t_val, k_val, cfg_musiccoca_val, cfg_notes_val, cfg_drums_val,
-        neg_musiccoca.values, neg_notes.values, empty_forced_tokens, *flat_state
-    )
+        warmup_args = [block.values, t_val, k_val]
+        for cfg in exp.input_configs:
+            if cfg.key == MUSICCOCA.key:
+                warmup_args.append(cfg_musiccoca_val)
+            elif cfg.key == PIANOROLL_WITH_ONSETS.key:
+                warmup_args.append(cfg_notes_val)
+            elif cfg.key == DRUM_PIANOROLL.key:
+                warmup_args.append(cfg_drums_val)
+            elif cfg.key == INPUT_SPECTROSTREAM.key:
+                warmup_args.append(cfg_audio_val)
+            elif cfg.key == MOSIC.key:
+                warmup_args.append(cfg_mosic_val)
+        for key in cfg_keys:
+            warmup_args.append(negatives[key].values)
+        warmup_args.append(empty_forced_tokens)
+        warmup_args.extend(flat_state)
+
+        y_values, *flat_state = streaming_step(*warmup_args)
         mx.eval(y_values, *flat_state)  # Force evaluation
     print("warmed up.")
 
@@ -486,32 +547,46 @@ def main(
     # todo: using shapeless=True could have performance cost, but
     # it would allow us to do parallel prefill over inputs with a dynamic time axis.
     with mx.exporter(mlxfn_path, streaming_step, shapeless=False) as exporter:
+        # Build export args list dynamically
+        args = [block.values, t_val, k_val]
+        for cfg in exp.input_configs:
+            if cfg.key == MUSICCOCA.key:
+                args.append(cfg_musiccoca_val)
+            elif cfg.key == PIANOROLL_WITH_ONSETS.key:
+                args.append(cfg_notes_val)
+            elif cfg.key == DRUM_PIANOROLL.key:
+                args.append(cfg_drums_val)
+            elif cfg.key == INPUT_SPECTROSTREAM.key:
+                args.append(cfg_audio_val)
+            elif cfg.key == MOSIC.key:
+                args.append(cfg_mosic_val)
+        for key in cfg_keys:
+            args.append(negatives[key].values)
+        args.append(empty_forced_tokens)
+        args.extend(flat_state)
 
-        exporter(
-            block.values,
-            t_val,
-            k_val,
-            cfg_musiccoca_val,
-            cfg_notes_val,
-            cfg_drums_val,
-            neg_musiccoca.values,
-            neg_notes.values,
-            empty_forced_tokens,
-            *flat_state,
-        )
+        exporter(*args)
         forced_tokens = mx.zeros((1, 1, rvq_truncation), dtype=mx.int32)
-        exporter(
-            block.values,
-            t_val,
-            k_val,
-            cfg_musiccoca_val,
-            cfg_notes_val,
-            cfg_drums_val,
-            neg_musiccoca.values,
-            neg_notes.values,
-            forced_tokens,
-            *flat_state,
-        )
+        
+        # Build step 2 args dynamically
+        # (re-uses values, state is modified so it doesn't matter)
+        args2 = [block.values, t_val, k_val]
+        for cfg in exp.input_configs:
+            if cfg.key == MUSICCOCA.key:
+                args2.append(cfg_musiccoca_val)
+            elif cfg.key == PIANOROLL_WITH_ONSETS.key:
+                args2.append(cfg_notes_val)
+            elif cfg.key == DRUM_PIANOROLL.key:
+                args2.append(cfg_drums_val)
+            elif cfg.key == INPUT_SPECTROSTREAM.key:
+                args2.append(cfg_audio_val)
+            elif cfg.key == MOSIC.key:
+                args2.append(cfg_mosic_val)
+        for key in cfg_keys:
+            args2.append(negatives[key].values)
+        args2.append(forced_tokens)
+        args2.extend(flat_state)
+        exporter(*args2)
 
     print(f'Exported transformer to {mlxfn_path}')
 

--- a/magenta_rt/mlx/generate.py
+++ b/magenta_rt/mlx/generate.py
@@ -18,6 +18,8 @@ import logging
 import time
 
 from magenta_rt import paths
+from magenta_rt.config import MUSICCOCA
+
 
 logging.basicConfig(level=logging.INFO, force=True)
 
@@ -38,14 +40,19 @@ def main(
     duration: float = 4.0,
     use_mlxfn: bool = True,
 ):
+    cfg_scales = {
+        'musiccoca': cfg_musiccoca,
+        'notes': cfg_notes,
+        'drums': 1.0,
+    }
+    
     if use_mlxfn:
-        from magenta_rt import MagentaRT2Mlxfn
-        mrt = MagentaRT2Mlxfn(
+        from magenta_rt import MagentaRT2StdMlxfn
+        mrt = MagentaRT2StdMlxfn(
             size=model_name,
             temperature=temperature,
             top_k=top_k,
-            cfg_musiccoca=cfg_musiccoca,
-            cfg_notes=cfg_notes,
+            cfg_scales=cfg_scales
         )
     else:
         from magenta_rt import MagentaRT2Mlx
@@ -54,8 +61,7 @@ def main(
             checkpoint=checkpoint,
             temperature=temperature,
             top_k=top_k,
-            cfg_musiccoca=cfg_musiccoca,
-            cfg_notes=cfg_notes,
+            cfg_scales=cfg_scales,
             bits=bits,
             quantize_group_size=quantize_group_size,
         )
@@ -66,7 +72,7 @@ def main(
 
     # --- Benchmark ---
     start_time = time.time()
-    wav, state = mrt.generate(style=embedding, frames=frames)
+    wav, state = mrt.generate(conditioning={MUSICCOCA.key: embedding}, frames=frames)
     elapsed = time.time() - start_time
     ms_per_step = (elapsed / frames) * 1000
     print(f"Generated {frames} frames in {elapsed:.1f}s "
@@ -85,7 +91,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--model", default=paths.DEFAULT_MODEL_NAME, type=str,
                         help=f"Model variant name (default: {paths.DEFAULT_MODEL_NAME}).")
-    parser.add_argument("--bits", default=None, type=int, choices=[2, 3, 4, 5, 6, 8])
+    parser.add_argument("--bits", default=None, type=int, choices=[2, 3, 4, 5, 6, 8, 16, 32])
     parser.add_argument("--quantize-group-size", default=None, type=int,
         help="Only matters if `--bits` is set.")
     parser.add_argument("--prompt", default=None, type=str, help="Text conditioning for MusicCoCa.")

--- a/magenta_rt/mlx/generate.py
+++ b/magenta_rt/mlx/generate.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--model", default=paths.DEFAULT_MODEL_NAME, type=str,
                         help=f"Model variant name (default: {paths.DEFAULT_MODEL_NAME}).")
-    parser.add_argument("--bits", default=None, type=int, choices=[2, 3, 4, 5, 6, 8, 16, 32])
+    parser.add_argument("--bits", default=None, type=int, choices=[2, 3, 4, 5, 6, 8])
     parser.add_argument("--quantize-group-size", default=None, type=int,
         help="Only matters if `--bits` is set.")
     parser.add_argument("--prompt", default=None, type=str, help="Text conditioning for MusicCoCa.")

--- a/magenta_rt/mlx/model.py
+++ b/magenta_rt/mlx/model.py
@@ -257,7 +257,7 @@ class MagentaRT2ModelBase(metaclass=abc.ABCMeta):
 
     if self.use_pretrained_musiccoca_embedder:
       musiccoca_cfg = self.input_configs[0]
-      assert musiccoca_cfg.key == 'mulan_tokens_25hz', (
+      assert musiccoca_cfg.key == MUSICCOCA.key, (
           f'Expected first input config to be MusicCoca, got {musiccoca_cfg.key}'
       )
 

--- a/magenta_rt/mlx/system.py
+++ b/magenta_rt/mlx/system.py
@@ -340,12 +340,11 @@ class MagentaRT2System:
 
       # If it's CFG
       elif cfg.cfg_scale_keys:
-        step = 8.0 / (cfg.codebook_size - 1)
         tokens = []
         for scale_key in cfg.cfg_scale_keys:
           token = discretize_cfg(
             scales.get(scale_key, 3.0),
-            step,
+            cfg.step,
             cfg.codebook_size - 1
           )
           tokens.append(token)

--- a/magenta_rt/mlx/system.py
+++ b/magenta_rt/mlx/system.py
@@ -33,8 +33,6 @@ from .. import musiccoca
 from .. import paths
 from ..config import (
     DRUM_PIANOROLL,
-    INPUT_SPECTROSTREAM,
-    MOSIC,
     MUSICCOCA,
     PIANOROLL_WITH_ONSETS,
 )
@@ -203,8 +201,7 @@ class MagentaRT2System:
       temperature: Sampling temperature.
       top_k: Top-k sampling threshold.
       cfg_scales: Classifier-free guidance scale for the different inputs.
-          Standard models need musiccoca, notes, and drums, while A2A models
-          need musiccoca, audio, and mosic.
+          Standard models need musiccoca, notes, and drums.
           Note: The CFG scales don't expand the inference batch but are used
           as additional conditioning tokens.
       bits: Quantization bit width (4 or 8). None means no quantization.
@@ -516,8 +513,7 @@ class MagentaRT2SystemMlxfn:
       temperature: Sampling temperature.
       top_k: Top-k sampling threshold.
       cfg_scales: Classifier-free guidance scale for the different inputs.
-          Standard models need musiccoca, notes, and drums, while A2A models
-          need musiccoca, audio, and mosic.
+          Standard models need musiccoca, notes, and drums.
       warmup_steps: Number of warmup inference steps.
     """
     model_name = size or paths.DEFAULT_MODEL_NAME

--- a/magenta_rt/mlx/system.py
+++ b/magenta_rt/mlx/system.py
@@ -31,6 +31,13 @@ from .load_weights import load_weights
 from .. import audio
 from .. import musiccoca
 from .. import paths
+from ..config import (
+    DRUM_PIANOROLL,
+    INPUT_SPECTROSTREAM,
+    MOSIC,
+    MUSICCOCA,
+    PIANOROLL_WITH_ONSETS,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -182,9 +189,7 @@ class MagentaRT2System:
       checkpoint: str | None = None,
       temperature: float = 1.3,
       top_k: int = 40,
-      cfg_musiccoca: float = 3.0,
-      cfg_notes: float = 1.0,
-      cfg_drums: float = 1.0,
+      cfg_scales: dict[str, float] | None = None,
       bits: int | None = 8,
       quantize_group_size: int | None = None,
   ):
@@ -197,9 +202,11 @@ class MagentaRT2System:
       checkpoint: Override checkpoint filename. If None, looked up from size.
       temperature: Sampling temperature.
       top_k: Top-k sampling threshold.
-      cfg_musiccoca: Classifier-free guidance scale for MusicCoCa.
-      cfg_notes: Classifier-free guidance scale for notes.
-      cfg_drums: Classifier-free guidance scale for drums.
+      cfg_scales: Classifier-free guidance scale for the different inputs.
+          Standard models need musiccoca, notes, and drums, while A2A models
+          need musiccoca, audio, and mosic.
+          Note: The CFG scales don't expand the inference batch but are used
+          as additional conditioning tokens.
       bits: Quantization bit width (4 or 8). None means no quantization.
       quantize_group_size: Group size for quantization. If None, defaults to
           32 for 4-bit and 64 for 8-bit.
@@ -249,22 +256,15 @@ class MagentaRT2System:
     # --- Sampling defaults ---
     self.temperature = temperature
     self.top_k = top_k
-    self.cfg_musiccoca = cfg_musiccoca
-    self.cfg_notes = cfg_notes
-    self.cfg_drums = cfg_drums
+    self.cfg_scales = cfg_scales or {
+        'musiccoca': 3.0,
+        'notes': 1.0,
+        'drums': 1.0,
+    }
 
     # --- Derived constants ---
-    self._num_musiccoca_tokens = self._model.input_configs[0].rvq_truncation_level
-    self._num_notes = self._model.input_configs[1].rvq_truncation_level
-    self._drum_tokens = self._model.input_configs[2].rvq_truncation_level
-    self._cfg_tokens = sum(
-        cfg.rvq_truncation_level for cfg in self._model.input_configs[3:]
-    )
-    self._num_channels = (
-        self._num_musiccoca_tokens
-        + self._num_notes
-        + self._drum_tokens
-        + self._cfg_tokens
+    self._num_channels = sum(
+      x.rvq_truncation_level for x in self._model.input_configs
     )
 
     # --- Warm up ---
@@ -275,11 +275,11 @@ class MagentaRT2System:
     logger.info('Warming up...')
     t0 = time.time()
 
-    dummy_style = [1] * self._num_musiccoca_tokens
-    dummy_notes = [-1] * self._num_notes
-    dummy_drums = [-1] * self._drum_tokens
-    dummy_cfg = [-1] * self._cfg_tokens
-    block, constants = self._build_conditioning(dummy_style, dummy_notes, dummy_drums, dummy_cfg)
+    conditioning = {}
+    for cfg in self._model.input_configs:
+      conditioning[cfg.key] = [-1] * cfg.rvq_truncation_level
+
+    block, constants = self._build_conditioning(conditioning)
 
     input_spec = sl.ChannelSpec(
         shape=(self._num_channels,), dtype=mx.int32,
@@ -316,10 +316,8 @@ class MagentaRT2System:
 
   def _build_conditioning(
       self,
-      style: musiccoca.StyleTokens | list[int],
-      notes: list[int] | None = None,
-      drums: list[int] | None = None,
-      cfgs: list[int] | None = None,
+      conditioning: dict[str, list[int] | np.ndarray],
+      cfg_scales: dict[str, float] | None = None,
       temperature: float | None = None,
       top_k: int | None = None,
   ) -> tuple[sl.Sequence, dict]:
@@ -330,37 +328,47 @@ class MagentaRT2System:
       and constants contains temperature, top_k, CFG scales, and negative
       conditioning sequences.
     """
+    cond_list = []
 
-    style_tokens = list(style) if not isinstance(style, list) else style
-    notes_tokens = notes if notes is not None else [-1] * self._num_notes
-    drums_tokens = drums if drums is not None else [-1] * self._drum_tokens
-    # Default cfgs_tokens [20, 20, 4] => cfg values [3.0, 3.0, 3.0]
-    if cfgs is None:
-      cfgs_tokens = [
-          int((self.cfg_musiccoca + 1.0) / 0.2),
-          int((self.cfg_notes + 1.0) / 0.2),
-          4,
-      ]
-    else:
-      cfgs_tokens = cfgs
+    # Merge class defaults with passed overrides
+    scales = self.cfg_scales.copy() if self.cfg_scales else {}
+    if cfg_scales:
+      scales.update(cfg_scales)
 
-    assert len(style_tokens) == self._num_musiccoca_tokens, (
-        f'Expected {self._num_musiccoca_tokens} style tokens, got {len(style_tokens)}'
-    )
-    assert len(notes_tokens) == self._num_notes, (
-        f'Expected {self._num_notes} notes, got {len(notes_tokens)}'
-    )
-    assert len(drums_tokens) == self._drum_tokens, (
-        f'Expected {self._drum_tokens} drums, got {len(drums_tokens)}'
-    )
-    assert len(cfgs_tokens) == self._cfg_tokens, (
-        f'Expected {self._cfg_tokens} CFG tokens, got {len(cfgs_tokens)}'
-    )
+    # ---
+    for cfg in self._model.input_configs:
+      # If the tokens were passed as conditioning
+      if cfg.key in conditioning:
+        tokens = list(conditioning[cfg.key])
+
+      # If it's CFG
+      elif cfg.cfg_scale_keys:
+        step = 8.0 / (cfg.codebook_size - 1)
+        tokens = []
+        for scale_key in cfg.cfg_scale_keys:
+          token = discretize_cfg(
+            scales.get(scale_key, 3.0),
+            step,
+            cfg.codebook_size - 1
+          )
+          tokens.append(token)
+        
+        tokens = tokens[:cfg.rvq_truncation_level]
+      
+      # Otherwise, use default unconditioned tokens
+      else:
+        tokens = [-1] * cfg.rvq_truncation_level
+
+      assert len(tokens) == cfg.rvq_truncation_level, (
+          f'Expected {cfg.rvq_truncation_level} tokens for {cfg.key},'
+          f' got {len(tokens)}'
+      )
+      cond_list.extend(tokens)
 
     offset = NUM_RESERVED_TOKENS + 1  # +1 for dropout token
 
     # Positive conditioning.
-    cond = np.array(style_tokens + notes_tokens + drums_tokens + cfgs_tokens, dtype=np.int32) + offset
+    cond = np.array(cond_list, dtype=np.int32) + offset
     block = sl.Sequence(
         mx.array(cond.reshape(1, 1, -1), dtype=mx.int32),
         mx.array([[True]], dtype=mx.bool_),
@@ -376,12 +384,8 @@ class MagentaRT2System:
 
   def generate(
       self,
-      style: musiccoca.StyleEmbedding | None = None,
-      notes: list[int] | None = None,
-      drums: list[int] | None = None,
-      cfg_musiccoca: float | None = None,
-      cfg_notes: float | None = None,
-      cfg_drums: float | None = None,
+      conditioning: dict[str, list[int] | np.ndarray] | None = None,
+      cfg_scales: dict[str, float] | None = None,
       temperature: float | None = None,
       top_k: int | None = None,
       frames: int = 25,
@@ -390,30 +394,10 @@ class MagentaRT2System:
     """Generate audio from style conditioning.
 
     Args:
-      style: Style embedding (768-dim ndarray from embed_style). None means
-          unconditional/masked.
-      notes: Notes conditioning (128 ints). Each slot represents the state of
-          the corresponding pitch (0-127). The state can be:
-          -1: means the pitch is masked out.
-           0: means the pitch is off.
-           1: means the pitch is on, but it's not the first time.
-           2: means the pitch is on for the first time (i.e., onset)
-           3: means the pitch is on (model has the freedom to play it as an
-              onset or continuation).
-        None means masked/silent (all pitches masked out).
-      drums: Drums conditioning (1 int).
-        -1: means masked
-         0: no drum
-         1: play drum
-      cfg_musiccoca: MusicCoCa classifier-free-guidance scale, a float in
-        [-1.0, 7.0]. None falls back to ``self.cfg_musiccoca``. Discretized to
-        a conditioning token with a 0.2 step (token 0 -> -1.0, token 1 -> -0.8,
-        ..., token 40 -> 7.0).
-      cfg_notes: Notes CFG scale, a float in [-1.0, 7.0]. None falls back to
-        ``self.cfg_notes``. Discretized with a 0.2 step like cfg_musiccoca.
-      cfg_drums: Drums CFG scale, a float in [-1.0, 7.0]. None falls back to
-        ``self.cfg_drums``. Discretized with a 1.0 step (token 0 -> -1.0,
-        token 1 -> 0.0, ..., token 8 -> 7.0).
+      conditioning: Dictionary mapping TokensConfig.key strings to their values
+        Values can be lists of integers (tokens) or raw embeddings (e.g. Style)
+      cfg_scales: Optional dictionary to override default CFG scales for this call.
+          Example: {'musiccoca': 5.0, 'notes': 3.0}
       temperature: Sampling temperature. None falls back to
         ``self.temperature``.
       top_k: Top-k sampling threshold. None falls back to ``self.top_k``.
@@ -425,30 +409,40 @@ class MagentaRT2System:
       (waveform, state) — a Waveform at 48kHz stereo, and the updated state
       for continuation.
     """
-    # --- Resolve style to tokens ---
-    if style is None:
-      style_tokens = [-1] * self._num_musiccoca_tokens
-    else:
-      style_tokens = self._style_model.tokenize(style).tolist()
+    conditioning = conditioning or {}
+    tokenized_conditioning = {}
+    
+    for key, value in conditioning.items():
+      if value is None:
+        continue
 
-    # Pad or truncate to expected length.
-    if len(style_tokens) < self._num_musiccoca_tokens:
-      style_tokens = style_tokens + [-1] * (self._num_musiccoca_tokens - len(style_tokens))
-    style_tokens = style_tokens[:self._num_musiccoca_tokens]
+      # If it's already an array or list of tokens (not float embedding), no need to tokenize
+      if isinstance(value, np.ndarray) and value.dtype in (np.float32, np.float64, np.float16, mx.float32, mx.float16, mx.bfloat16):
+        pass # Float embedding, needs tokenization
+      elif isinstance(value, (list, np.ndarray)):
+        tokenized_conditioning[key] = list(value)
+        continue
 
-    # --- Resolve CFG scales and discretize to conditioning tokens ---
-    cfg_musiccoca = self.cfg_musiccoca if cfg_musiccoca is None else cfg_musiccoca
-    cfg_notes = self.cfg_notes if cfg_notes is None else cfg_notes
-    cfg_drums = self.cfg_drums if cfg_drums is None else cfg_drums
-    cfgs = [
-        discretize_cfg(cfg_musiccoca, 0.2, 40),
-        discretize_cfg(cfg_notes, 0.2, 40),
-        discretize_cfg(cfg_drums, 1.0, 8),
-    ]
+      # Otherwise, get truncation level and tokenize
+      cfg = next((c for c in self._model.input_configs if c.key == key), None)
+      if cfg is None:
+        raise ValueError(f'No config found for key {key}')
+
+      if key == MUSICCOCA.key:
+        tokens = self._style_model.tokenize(value).tolist()
+      else:
+        raise ValueError(
+          f"Automatic tokenization for '{key}' is not implemented."
+        )
+
+      # Pad or truncate to expected length.
+      if len(tokens) < cfg.rvq_truncation_level:
+        tokens = tokens + [-1] * (cfg.rvq_truncation_level - len(tokens))
+      tokenized_conditioning[key] = tokens[:cfg.rvq_truncation_level]
 
     # --- Build conditioning ---
     block, constants = self._build_conditioning(
-        style_tokens, notes, drums, cfgs, temperature, top_k
+        tokenized_conditioning, cfg_scales, temperature, top_k
     )
 
     # --- Init state if needed ---
@@ -510,9 +504,7 @@ class MagentaRT2SystemMlxfn:
       style_model: musiccoca.MusicCoCa | None = None,
       temperature: float = 1.3,
       top_k: int = 40,
-      cfg_musiccoca: float = 3.0,
-      cfg_notes: float = 1.0,
-      cfg_drums: float = 1.0,
+      cfg_scales: dict[str, float] | None = None,
       warmup_steps: int = 5,
   ):
     """Initialise from an exported .mlxfn model directory.
@@ -523,9 +515,9 @@ class MagentaRT2SystemMlxfn:
           a default MusicCoCa is created.
       temperature: Sampling temperature.
       top_k: Top-k sampling threshold.
-      cfg_musiccoca: Classifier-free guidance scale for MusicCoCa.
-      cfg_notes: Classifier-free guidance scale for notes.
-      cfg_drums: Classifier-free guidance scale for drums.
+      cfg_scales: Classifier-free guidance scale for the different inputs.
+          Standard models need musiccoca, notes, and drums, while A2A models
+          need musiccoca, audio, and mosic.
       warmup_steps: Number of warmup inference steps.
     """
     model_name = size or paths.DEFAULT_MODEL_NAME
@@ -549,23 +541,22 @@ class MagentaRT2SystemMlxfn:
     mx.eval(self._initial_state)
     logger.info('Loaded %d state arrays', len(self._initial_state))
 
-    self._rvq_depth = 12
-
     # --- Style model ---
     self._style_model = style_model or musiccoca.MusicCoCa()
 
     # --- Conditioning layout ---
-    self._num_musiccoca_tokens = 12
-    self._num_notes = 128
-    self._num_drums = 1
-    self._num_cfgs = 3  # musiccoca-cfg, notes-cfg, drums-cfg
+    model_instance = model_configs.get_model_class(model_name)()
+    self.input_configs = model_instance.input_configs
+    self._rvq_depth = model_instance.target_tokens_config.rvq_truncation_level
 
     # --- Sampling parameters ---
     self.temperature = temperature
     self.top_k = top_k
-    self.cfg_musiccoca = cfg_musiccoca
-    self.cfg_notes = cfg_notes
-    self.cfg_drums = cfg_drums
+    self.cfg_scales = cfg_scales or {
+        'musiccoca': 3.0,
+        'notes': 1.0,
+        'drums': 1.0,
+    }
 
     self._sample_rate = 48_000
 
@@ -576,9 +567,12 @@ class MagentaRT2SystemMlxfn:
     """Run a few dummy steps to warm up MLX kernel caches."""
     logger.info('Warming up (%d steps)...', steps)
     t0 = time.time()
-    args = self._build_mlxfn_args(
-        style_tokens=[-1] * self._num_musiccoca_tokens,
-    )
+    
+    conditioning = {}
+    for cfg in self.input_configs:
+      conditioning[cfg.key] = [-1] * cfg.rvq_truncation_level
+      
+    args = self._build_mlxfn_args(conditioning)
     state = list(self._initial_state)
     for _ in range(steps):
       outputs = self._fn(args + state)
@@ -607,115 +601,97 @@ class MagentaRT2SystemMlxfn:
 
   def _build_mlxfn_args(
       self,
-      style_tokens: list[int],
-      notes: list[int] | None = None,
-      drums: list[int] | None = None,
-      cfg_musiccoca: float | None = None,
-      cfg_notes: float | None = None,
-      cfg_drums: float | None = None,
+      conditioning: dict[str, list[int] | np.ndarray],
+      cfg_scales: dict[str, float] | None = None,
       temperature: float | None = None,
       top_k: int | None = None,
   ) -> list[mx.array]:
     """Build the flat arg list expected by the exported mlxfn.
 
-    The exported function signature is:
-        fn([cond, temperature, top_k, cfg_musiccoca, cfg_notes, cfg_drums,
-            neg_musiccoca, neg_notes, forced_tokens, *state])
-
     Returns:
       List of mx.array arguments (without state — caller appends that).
     """
-    notes_tokens = notes if notes is not None else [-1] * self._num_notes
-    drums_tokens = drums if drums is not None else [-1] * self._num_drums
+    
+    cond_list = []
+    tokenized_conditioning = {}
 
-    cfg_musiccoca = self.cfg_musiccoca if cfg_musiccoca is None else cfg_musiccoca
-    cfg_notes = self.cfg_notes if cfg_notes is None else cfg_notes
-    cfg_drums = self.cfg_drums if cfg_drums is None else cfg_drums
+    for cfg in self.input_configs:
+      if cfg.cfg_scale_keys:
+        continue # CFG scales are not discretized in cond array for mlxfn
+      elif cfg.key in conditioning:
+        tokens = list(conditioning[cfg.key])
+      else:
+        tokens = [-1] * cfg.rvq_truncation_level # default
+        
+      assert len(tokens) == cfg.rvq_truncation_level, (
+          f'Expected {cfg.rvq_truncation_level} tokens for {cfg.key},'
+          f' got {len(tokens)}'
+      )
+      tokenized_conditioning[cfg.key] = tokens
+      cond_list.extend(tokens)
+      
+    cond = np.array(cond_list, dtype=np.int32) + self._TOKEN_OFFSET
+    cond_array = mx.array(cond.reshape(1, 1, -1), dtype=mx.int32)
+
+    scales = self.cfg_scales.copy() if self.cfg_scales else {}
+    if cfg_scales:
+      scales.update(cfg_scales)
+    
     temperature = self.temperature if temperature is None else temperature
     top_k = self.top_k if top_k is None else top_k
 
-    offset = self._TOKEN_OFFSET
+    return self._build_graph_args(
+        cond_array, tokenized_conditioning, scales, temperature, top_k
+    )
 
-    # Positive conditioning (12 + 128 + 1 = 141 tokens)
-    cond = np.array(
-        style_tokens + notes_tokens + drums_tokens,
-        dtype=np.int32,
-    ) + offset
-    cond_array = mx.array(cond.reshape(1, 1, -1), dtype=mx.int32)
-
-    # Negative conditioning (masked style)
-    masked_style = [-1] * len(style_tokens)
-    neg_mc = np.array(
-        masked_style + notes_tokens + drums_tokens,
-        dtype=np.int32,
-    ) + offset
-    neg_mc_array = mx.array(neg_mc.reshape(1, 1, -1), dtype=mx.int32)
-
-    # Negative conditioning (masked notes)
-    masked_notes = [-1] * len(notes_tokens)
-    neg_n = np.array(
-        style_tokens + masked_notes + drums_tokens,
-        dtype=np.int32,
-    ) + offset
-    neg_n_array = mx.array(neg_n.reshape(1, 1, -1), dtype=mx.int32)
-
-    return [
-        cond_array,
-        mx.array([temperature]),
-        mx.array([top_k], dtype=mx.int32),
-        mx.array([cfg_musiccoca]),
-        mx.array([cfg_notes]),
-        mx.array([cfg_drums]),
-        neg_mc_array,
-        neg_n_array,
-        mx.zeros((1, 0, self._rvq_depth), dtype=mx.int32),  # forced_tokens
-    ]
+  def _build_graph_args(
+      self,
+      cond_array: mx.array,
+      tokenized: dict[str, list[int]],
+      scales: dict[str, float],
+      temperature: float,
+      top_k: int,
+  ) -> list[mx.array]:
+    raise NotImplementedError("Subclasses must implement _build_graph_args")
 
   def generate(
       self,
-      style: musiccoca.StyleEmbedding | None = None,
-      notes: list[int] | None = None,
-      drums: list[int] | None = None,
-      cfg_musiccoca: float | None = None,
-      cfg_notes: float | None = None,
-      cfg_drums: float | None = None,
+      conditioning: dict[str, list[int] | np.ndarray] | None = None,
+      cfg_scales: dict[str, float] | None = None,
       temperature: float | None = None,
       top_k: int | None = None,
       frames: int = 25,
       state: list[mx.array] | None = None,
   ) -> tuple[audio.Waveform, list[mx.array]]:
-    """Generate audio from style conditioning.
+    
+    conditioning = conditioning or {}
+    tokenized_conditioning = {}
+    
+    for key, value in conditioning.items():
+      if value is None:
+        continue
 
-    Args:
-      style: Style embedding from embed_style(). None means unconditional.
-      notes: Notes conditioning (128 ints, see MagentaRT2System.generate).
-      drums: Drums conditioning (1 int). -1=masked, 0=off, 1=on.
-      cfg_musiccoca: Classifier-free guidance scale for MusicCoCa.
-      cfg_notes: Classifier-free guidance scale for notes.
-      cfg_drums: Classifier-free guidance scale for drums.
-      temperature: Sampling temperature.
-      top_k: Top-k sampling threshold.
-      frames: Number of frames to generate (25 frames ≈ 1 second at 48kHz).
-      state: Streaming state from a previous call. If None, uses initial state.
+      if isinstance(value, np.ndarray) and value.dtype in (np.float32, np.float64, np.float16, mx.float32, mx.float16, mx.bfloat16):
+        pass # Float embedding, needs tokenization
+      elif isinstance(value, (list, np.ndarray)):
+        tokenized_conditioning[key] = list(value)
+        continue
 
-    Returns:
-      (waveform, state) — Waveform at 48kHz stereo, and the updated state.
-    """
-    # --- Resolve style to tokens ---
-    if style is None:
-      style_tokens = [-1] * self._num_musiccoca_tokens
-    else:
-      style_tokens = self._style_model.tokenize(style).tolist()
+      cfg = next((c for c in self.input_configs if c.key == key), None)
+      if cfg is None:
+        raise ValueError(f'No config found for key {key}')
 
-    # Pad / truncate
-    if len(style_tokens) < self._num_musiccoca_tokens:
-      style_tokens += [-1] * (self._num_musiccoca_tokens - len(style_tokens))
-    style_tokens = style_tokens[:self._num_musiccoca_tokens]
+      if key == MUSICCOCA.key:
+        tokens = self._style_model.tokenize(value).tolist()
+      else:
+        raise ValueError(f"Automatic tokenization for '{key}' is not implemented.")
+        
+      if len(tokens) < cfg.rvq_truncation_level:
+        tokens = tokens + [-1] * (cfg.rvq_truncation_level - len(tokens))
+      tokenized_conditioning[key] = tokens[:cfg.rvq_truncation_level]
 
-    # --- Build args ---
     args = self._build_mlxfn_args(
-        style_tokens, notes, drums, cfg_musiccoca, cfg_notes, cfg_drums,
-        temperature, top_k
+        tokenized_conditioning, cfg_scales, temperature, top_k
     )
 
     # --- Init state if needed ---
@@ -748,3 +724,48 @@ class MagentaRT2SystemMlxfn:
         sample_rate=self._sample_rate,
     )
     return waveform, state
+
+
+class MagentaRT2SystemStdMlxfn(MagentaRT2SystemMlxfn):
+  """Standard MagentaRT2 .mlxfn wrapper (musiccoca, notes, drums)."""
+  def _build_graph_args(
+      self,
+      cond_array: mx.array,
+      tokenized: dict[str, list[int]],
+      scales: dict[str, float],
+      temperature: float,
+      top_k: int,
+  ) -> list[mx.array]:
+    """
+    The exported function signature is:
+        fn([cond, temperature, top_k, cfg_musiccoca, cfg_notes, cfg_drums,
+            neg_musiccoca, neg_notes, forced_tokens, *state])
+    """
+    style_tokens = tokenized.get(MUSICCOCA.key, [])
+    notes_tokens = tokenized.get(PIANOROLL_WITH_ONSETS.key, [])
+    drums_tokens = tokenized.get(DRUM_PIANOROLL.key, [])
+    
+    masked_style = [-1] * len(style_tokens)
+    meg_musiccoca = np.array(masked_style + notes_tokens + drums_tokens, dtype=np.int32) + self._TOKEN_OFFSET
+    meg_musiccoca_array = mx.array(meg_musiccoca.reshape(1, 1, -1), dtype=mx.int32)
+
+    masked_notes = [-1] * len(notes_tokens)
+    neg_n = np.array(style_tokens + masked_notes + drums_tokens, dtype=np.int32) + self._TOKEN_OFFSET
+    neg_n_array = mx.array(neg_n.reshape(1, 1, -1), dtype=mx.int32)
+
+    cfg_musiccoca = scales.get('musiccoca', 3.0)
+    cfg_notes = scales.get('notes', 1.0)
+    cfg_drums = scales.get('drums', 1.0)
+
+    return [
+        cond_array,
+        mx.array([temperature]),
+        mx.array([top_k], dtype=mx.int32),
+        mx.array([cfg_musiccoca]),
+        mx.array([cfg_notes]),
+        mx.array([cfg_drums]),
+        meg_musiccoca_array,
+        neg_n_array,
+        mx.zeros((1, 0, self._rvq_depth), dtype=mx.int32),  # forced_tokens
+    ]
+

--- a/scripts/bench_track.py
+++ b/scripts/bench_track.py
@@ -173,7 +173,7 @@ def main():
 
     # ── 3) Benchmark ──────────────────────────────────────────────────────
     print("━━━ [3/3] Benchmark ━━━")
-    bench_cmd = [BENCHMARK_BIN, model_dir, str(args.steps), str(DEFAULT_NUM_CFGS)]
+    bench_cmd = [BENCHMARK_BIN, model_dir, str(args.steps)]
     rc, output = run_cmd(bench_cmd, capture=True)
     if rc != 0:
         sys.exit(f"❌ Benchmark failed (exit {rc})")

--- a/scripts/bench_track.py
+++ b/scripts/bench_track.py
@@ -38,6 +38,7 @@ LOG_FILE = "outputs/bench_track/benchmark_log.jsonl"
 BENCHMARK_BIN = "./benchmark_build/benchmark_mlxfn"
 BENCH_DIR = "outputs/bench_track"
 MODEL_PREFIX = "mrt2_small"
+DEFAULT_NUM_CFGS = 0
 
 
 def git_sha():
@@ -143,7 +144,7 @@ def main():
             "mrt", "mlx", "export",
             f"--checkpoint={MODEL_PREFIX}.safetensors",
             f"--model={MODEL_PREFIX}",
-            "--num-cfgs=0",
+            f"--num-cfgs={DEFAULT_NUM_CFGS}",
             f"--bits={args.bits}",
             f"--output-name={output_name}",
             f"--output-dir={BENCH_DIR}",
@@ -172,7 +173,7 @@ def main():
 
     # ── 3) Benchmark ──────────────────────────────────────────────────────
     print("━━━ [3/3] Benchmark ━━━")
-    bench_cmd = [BENCHMARK_BIN, model_dir, str(args.steps)]
+    bench_cmd = [BENCHMARK_BIN, model_dir, str(args.steps), str(DEFAULT_NUM_CFGS)]
     rc, output = run_cmd(bench_cmd, capture=True)
     if rc != 0:
         sys.exit(f"❌ Benchmark failed (exit {rc})")

--- a/scripts/bulk_generate.py
+++ b/scripts/bulk_generate.py
@@ -30,7 +30,8 @@ import pandas as pd
 from pathlib import Path
 from scipy.io import wavfile
 
-from magenta_rt import MagentaRT2Mlxfn
+from magenta_rt import MagentaRT2StdMlxfn
+from magenta_rt.config import MUSICCOCA
 
 logging.basicConfig(level=logging.INFO, force=True)
 
@@ -53,12 +54,15 @@ def main():
     frames = args.duration_sec * 25  # 25 fps
 
     # --- Init system ---
-    mrt = MagentaRT2Mlxfn(
+    mrt = MagentaRT2StdMlxfn(
         size=args.size,
         temperature=args.temperature,
         top_k=args.top_k,
-        cfg_musiccoca=args.cfg_musiccoca,
-        cfg_notes=args.cfg_notes,
+        cfg_scales={
+            'musiccoca': args.cfg_musiccoca,
+            'notes': args.cfg_notes,
+            'drums': 1.0,
+        }
     )
 
     # --- Load prompts ---
@@ -78,7 +82,7 @@ def main():
         embedding = mrt.embed_style(prompt_text, use_mapper=True)
 
         start_time = time.time()
-        wav, _ = mrt.generate(style=embedding, frames=frames)
+        wav, _ = mrt.generate(conditioning={MUSICCOCA.key: embedding}, frames=frames)
         elapsed = time.time() - start_time
         print(f"  Done in {elapsed:.1f}s ({frames/elapsed:.1f} steps/s)")
 


### PR DESCRIPTION
## Local Pytests

> [!NOTE]
> Use `mrt models init` to download the necessary resources. Then use `mrt checkpoints download` to download `mrt2_small.safetensors` and `mrt2_base.safetensors`

I ran
```bash
mrt jax generate --model=mrt2_small
mrt mlx generate --model=mrt2_small
mrt mlx generate --model=mrt2_small --no-mlxfn --bits=8

pytest -s tests/test_musiccoca.py
pytest -s tests/test_prefill_correctness.py

python scripts/generate_test_reference.py
pytest -s tests/test_bitlevel_parity.py
```
and observed the following output:
```
all passed
```

## Benchmark Regression Test

I ran
```bash
python scripts/bench_track.py
python scripts/bench_show.py --samples
```
and observed the following output:
```
2026-07-27T14:35:40 mrt2_small_int8_rvq12_cfgs0_260727_e56b15b      e56b15b    11.2   11.2   11.5   11.7   88.9  ✅ WITHIN BUDGET
                      ↳ [M4 Pro]
                      L: [-0.01214600, -0.01123047, -0.01174927, -0.01290894, -0.01229858, -0.01040649, -0.01046753, -0.01254272, -0.01406860, -0.01489258]
                      R: [-0.01068115, -0.00979614, -0.01040649, -0.01205444, -0.01242065, -0.01083374, -0.01028442, -0.01165771, -0.01266479, -0.01324463]
```
