### PR TITLE
Fix prefilling forced tokens not being passed through

### DIFF
--- a/magenta_rt/mlx/depthformer.py
+++ b/magenta_rt/mlx/depthformer.py
@@ -684,6 +684,10 @@ class MultivariateDecoder(sl.Emitting):
     # Note: forced_tokens is an MLX-specific feature to allow forcing tokens
     # during step-by-step generation, which is not present in JAX.
     if forced_tokens is not None and forced_tokens.shape[1] > 0:
+      # Broadcast forced_tokens to match batch size (e.g., if using CFG)
+      if forced_tokens.shape[0] != batch_size:
+        forced_tokens = mx.broadcast_to(forced_tokens, (batch_size,) + forced_tokens.shape[1:])
+      forced_tokens = forced_tokens.astype(mx.uint32)
       depth_samples = sl.Sequence.from_values(forced_tokens)
       state = (rng, depth_samples, temporal_state, step + 1)
       return depth_samples, state, None

--- a/tests/test_bitlevel_parity.py
+++ b/tests/test_bitlevel_parity.py
@@ -133,7 +133,7 @@ def _run_temporal_step(mrt_sampler, constants, block):
     captured = {}
     original_step = depthformer.MultivariateDecoder.step_with_emits
 
-    def _patched_step(self, x, state_inner, *, training=False, constants=None):
+    def _patched_step(self, x, state_inner, *, training=False, constants=None, **kwargs):
         rng, previous_frame, temporal_state, step = state_inner
         constants = constants or {}
         batch_size, _, _ = previous_frame.shape
@@ -155,7 +155,7 @@ def _run_temporal_step(mrt_sampler, constants, block):
         captured['batch_size'] = batch_size
         captured['training'] = training
 
-        return original_step(self, x, state_inner, training=training, constants=constants)
+        return original_step(self, x, state_inner, training=training, constants=constants, **kwargs)
 
     depthformer.MultivariateDecoder.step_with_emits = _patched_step
     try:

--- a/tests/test_prefill_correctness.py
+++ b/tests/test_prefill_correctness.py
@@ -106,6 +106,7 @@ class TestPrefillCorrectness(unittest.TestCase):
             prev_token = prefill_seq[:, step:step+1, :]
             y, state = sampler.step(x=self.block, state=state, forced_tokens=prev_token, constants=self.constants)
             mx.eval(y.values, state)
+            npt.assert_array_equal(y.values, prev_token, err_msg=f"Output at step {step} does not match forced tokens")
 
         # Seed previous_frame with the last token without calling the model
         enc_state, prev_out, samp_state, delay = state


### PR DESCRIPTION
## Local Pytests

> [!NOTE]
> Use `mrt models init` to download the necessary resources. Then use `mrt checkpoints download` to download `mrt2_small.safetensors` and `mrt2_base.safetensors`

I ran
```bash
mrt jax generate --model=mrt2_small
mrt mlx generate --model=mrt2_small
mrt mlx generate --model=mrt2_small --no-mlxfn --bits=8

pytest -s tests/test_musiccoca.py
pytest -s tests/test_prefill_correctness.py

python scripts/generate_test_reference.py
pytest -s tests/test_bitlevel_parity.py
```
and observed the following output:
```
all passed
```

## Benchmark Regression Test

I ran
```bash
python scripts/bench_track.py
python scripts/bench_show.py --samples
```
and observed the following output:
```
2026-07-28T17:07:53 mrt2_small_int8_rvq12_cfgs0_260728_53d808f      53d808f    11.4   11.2   12.4   13.4   87.5  ✅ WITHIN BUDGET
                      ↳ [M4 Pro]
                      L: [-0.01214600, -0.01123047, -0.01174927, -0.01290894, -0.01229858, -0.01040649, -0.01046753, -0.01254272, -0.01406860, -0.01489258]
                      R: [-0.01068115, -0.00979614, -0.01040649, -0.01205444, -0.01242065, -0.01083374, -0.01028442, -0.01165771, -0.01266479, -0.01324463]
```
